### PR TITLE
Updating OLS template

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ ModelManager is a small extension to UrbanSim that treats model steps as _object
 
 ```py
 from urbansim_templates import modelmanager as mm
-from urbansim_templates.models import RegressionStep
+from urbansim_templates.models import OLSRegressionStep
 
-model = RegressionStep('name', parameters)
+model = OLSRegressionStep('name', parameters)
 model.fit()
 model.register()
 
@@ -53,9 +53,9 @@ To work with ModelManager, a model step class needs to implement the following f
 
 #### Where's the code?
 
-If you look in the [models](https://github.com/urbansim/modelmanager/tree/master/modelmanager/models) directory you'll see an OLS model step class called `RegressionStep` that implements these features on top of an existing UrbanSim regression model class. 
+If you look in the [models](https://github.com/UDST/urbansim_templates/tree/master/urbansim_templates/models) directory you'll see an OLS model step class called `OLSRegressionStep` that implements these features on top of an existing UrbanSim regression model class. 
 
-The [modelmanager.py](https://github.com/urbansim/modelmanager/blob/master/modelmanager/modelmanager.py) file handles centralized saving and loading of the configs. 
+The [modelmanager.py](https://github.com/UDST/urbansim_templates/blob/master/urbansim_templates/modelmanager.py) file handles centralized saving and loading of the configs. 
 
 #### Where are model steps saved to?
 
@@ -65,31 +65,31 @@ In an UrbanSim project directory, the steps saved by ModelManager will show up i
 ## Installation
 
 ```
-git clone https://github.com/urbansim/modelmanager.git
-cd modelmanager
+git clone https://github.com/udst/urbansim_templates.git
+cd urbansim_templates
 python setup.py develop
 ```
 
 
 ## User's guide
 
-Demo notebook: [REPM estimation.ipynb](https://github.com/urbansim/parcel_template_sandbox/blob/master/notebooks/REPM%20estimation.ipynb)
+Demo notebook: [Demo.ipynb](https://github.com/ual/urbansim_parcel_bayarea/blob/master/notebooks-sam/Demo.ipynb)
 
 Choose a directory to work in, ideally an existing UrbanSim project since ModelManager cannot yet load data into Orca on its own.
 
 For building and registering model steps, use: 
 
 ```py
-from modelmanager.models import RegressionStep
+from urbansim_templates.models import OLSRegressionStep
 ```
 
 For loading or inspecting previously saved model steps, use:
 
 ```py
-import modelmanager as mm
+from urbansim_templates import modelmanager as mm
 ```
 
-For example, adding `import modelmanager` to the top of a file like `simulation.py` will automatically give Orca access to all previously saved steps in the same project directory.
+For example, adding `import urbansim_templates` to the top of a file like `simulation.py` will automatically give Orca access to all previously saved steps in the same project directory.
 
 Please refer to the Python files for details of the current API. 
 
@@ -105,17 +105,14 @@ Here's a rough development wish list. See issues for more details, and feel free
 
 #### Infrastructure:
 
-- is there a sample data set following the parcel template schema guidelines, that we can use for testing and development?
 - integration with Jupyter Lab in the cloud
 - unit tests and continuous integration hooks
-- documentation, releases, distribution details (later on)
+- documentation, releases, distribution details
 
 #### Features:
 
 - `datamanager.py` to support loading data and generating computed columns using a similar workflow (Sam M) 
 - various TO DO items in the code
-- class for binary logit model steps (Arezoo?)
-- class for multinomial logit model steps (Max?)
 - class for network aggregation model steps
 - classes for transition steps and other loose ends
 - class for developer model if feasible

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='urbansim_templates',
-    version='0.1.dev2',
+    version='0.1.dev3',
     description='UrbanSim extension for managing model steps',
     author='UrbanSim Inc.',
     author_email='info@urbansim.com',

--- a/urbansim_templates/__init__.py
+++ b/urbansim_templates/__init__.py
@@ -1,1 +1,0 @@
-from .modelmanager import *

--- a/urbansim_templates/modelmanager.py
+++ b/urbansim_templates/modelmanager.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 import orca
 from urbansim.utils import yamlio
 
-from .models import RegressionStep
+from .models import OLSRegressionStep
 from .models import BinaryLogitStep
 from .models import MNLDiscreteChoiceStep
 
@@ -112,12 +112,7 @@ def get_step(name):
     RegressionStep or other
     
     """
-    if (_STEPS[name]['type'] == 'RegressionStep'):
-        return RegressionStep.from_dict(_STEPS[name])
-    elif (_STEPS[name]['type'] == 'BinaryLogitStep'):
-        return BinaryLogitStep.from_dict(_STEPS[name])
-    elif (_STEPS[name]['type'] == 'MNLDiscreteChoiceStep'):
-        return MNLDiscreteChoiceStep.from_dict(_STEPS[name])
+    return globals()[_STEPS[name]['type']].from_dict(_STEPS[name])
 
 
 def save_steps_to_disk():

--- a/urbansim_templates/models/__init__.py
+++ b/urbansim_templates/models/__init__.py
@@ -1,4 +1,4 @@
 from .binary_logit import BinaryLogitStep
 from .dcm import MNLDiscreteChoiceStep
-from .regression import RegressionStep
+from .regression import OLSRegressionStep
 from .shared import TemplateStep

--- a/urbansim_templates/models/regression.py
+++ b/urbansim_templates/models/regression.py
@@ -8,79 +8,103 @@ import orca
 from urbansim.models import RegressionModel
 from urbansim.utils import yamlio
 
+from .shared import TemplateStep
 from .. import modelmanager as mm
 
 
-class RegressionStep(object):
+class OLSRegressionStep(TemplateStep):
     """
-    A class for building regression model steps. This wraps urbansim.models.
-    RegressionModel() and adds a number of features:
+    A class for building OLS (ordinary least squares) regression model steps. This extends 
+    TemplateStep, where some common functionality is defined. Estimation and simulation
+    are handled by `urbansim.models.RegressionModel()`.
     
-    1. Allows passing all parameters needed for the model step at once.
-    2. Allows direct registration of the model step with Orca and the ModelManager.
-    3. Adds ModelManager metadata: type, name, tags.
+    Expected usage:
+    - create a model object
+    - specify some parameters
+    - run the `fit()` method
+    - iterate as needed
     
-    Note that the same table and column names are used for both estimation and prediction,
-    although the dependent variable may be different if needed. This is in alignment with
-    the existing UrbanSim codebase.
+    Then, for simulation:
+    - specify some simulation parameters
+    - use the `run()` method for interactive testing
+    - use the `register()` method to save the model to Orca and disk
+    - registered steps can be accessed via ModelManager and Orca
     
+    All parameters listed in the constructor can be set directly on the class object,
+    at any time.
+
     Parameters
     ----------
-    model_expression : str
-        Passed to urbansim.models.RegressionModel().
-    tables : str or list of str
-        Name(s) of Orca tables to draw data from. The first table is the primary one.
+    tables : str or list of str, optional
+        Name(s) of Orca tables to draw data from. The first table is the primary one. 
         Any additional tables need to have merge relationships ("broadcasts") specified
-        so that they can be merged unambiguously onto the first table. 
-    fit_filters : list of str, optional
-        For estimation. Passed to urbansim.models.RegressionModel().
-    out_fname : str, optional
-        For prediction. Name of column to write fitted values to (in the primary table),
-        if different from the dependent variable used for estimation.
-    predict_filters : list of str, optional
-        For prediction. Passed to urbansim.models.RegressionModel().
-    ytransform : callable, optional
-        For prediction. Passed to urbansim.models.RegressionModel().
+        so that they can be merged unambiguously onto the first table. Among them, the 
+        tables must contain all variables used in the model expression and filters. The
+        left-hand-side variable should be in the primary table. The `tables` parameter is 
+        required for fitting a model, but it does not have to be provided when the object 
+        is created.
+
+    model_expression : str, optional
+        Patsy formula containing both the left- and right-hand sides of the model
+        expression: http://patsy.readthedocs.io/en/latest/formulas.html
+        This parameter is required for fitting a model, but it does not have to be 
+        provided when the object is created.
+
+    filters : str or list of str, optional
+        Filters to apply to the data before fitting the model. These are passed to 
+        `pd.DataFrame.query()`. Filters are applied after any additional tables are merged 
+        onto the primary one. Replaces the `fit_filters` argument in UrbanSim.
+    
+    out_tables : str or list of str, optional
+        Name(s) of Orca tables to use for simulation. If not provided, the `tables` 
+        parameter will be used. Same guidance applies: the tables must be able to be 
+        merged unambiguously, and must include all columns used in the right-hand-side
+        of the model expression and in the `out_filters`.
+    
+    out_column : str, optional
+        Name of the column to write predicted values to. If it does not already exist
+        in the primary output table, it will be created. If not provided, the left-hand-
+        side variable from the model expression will be used. Replaces the `out_fname` 
+        argument in UrbanSim.
+        
+        # TO DO - auto-generation not yet working; column must exist in the primary table
+    
+    out_transform : callable, optional
+        Transformation to apply to the predicted values, for example to reverse a 
+        transformation of the left-hand-side variable in the model expression. Replaces
+        the `ytransform` argument in UrbanSim.
+    
+    out_filters : str or list of str, optional
+        Filters to apply to the data before simulation. If not provided, no filters will
+        be applied. Replaces the `predict_filters` argument in UrbanSim.
+        
     name : str, optional
-        For ModelManager.
+        Name of the model step, passed to ModelManager. If none is provided, a name is
+        generated each time the `fit()` method runs.
+    
     tags : list of str, optional
-        For ModelManager.
+        Tags, passed to ModelManager.
     
     """
-    def __init__(self, model_expression, tables, fit_filters=None, out_fname=None,    
-            predict_filters=None, ytransform=None, name=None, tags=[]):
+    def __init__(self, tables=None, model_expression=None, filters=None, out_tables=None,
+            out_column=None, out_transform=None, out_filters=None, name=None, tags=[]):
         
-        self.model_expression = model_expression
-        self.tables = tables
-        self.fit_filters = fit_filters
-        self.out_fname = out_fname
-        self.predict_filters = predict_filters
-        self.ytransform = ytransform
-
-        # Placeholder for the RegressionModel object, which will be created either in the 
-        # fit() method or in the from_dict() class method
+        # Parent class can initialize the standard parameters
+        TemplateStep.__init__(self, tables=tables, model_expression=model_expression, 
+                filters=filters, out_tables=out_tables, out_column=out_column, 
+                out_transform=out_transform, out_filters=out_filters, name=name, 
+                tags=tags)
+        
+        # Placeholders for model fit data, filled in by fit() or from_dict()
+        self.summary_table = None 
+        self.fitted_parameters = None
         self.model = None
-        
-        self.type = 'RegressionStep'
-        self.name = name
-        self.tags = tags
-        
-        # Generate a name if none provided - TO DO: maybe this should be the time of 
-        # model fitting rather than the time the object is created, in order to be 
-        # consistent with the regression results that print?
-        if (self.name == None):
-            self.name = self.type + '-' + dt.now().strftime('%Y%m%d-%H%M%S')
-    
-        # TO DO: 
-        # - Figure out what we can infer about requirements for the underlying data, and
-        #   write an 'orca_test' assertion to confirm compliance.
 
     
     @classmethod
     def from_dict(cls, d):
         """
-        Create a RegressionStep object from a saved dictionary representation. (The  
-        resulting object can run() but cannot be fit() again.)
+        Create an object instance from a saved dictionary representation.
         
         Parameters
         ----------
@@ -88,116 +112,87 @@ class RegressionStep(object):
         
         Returns
         -------
-        RegressionStep
+        OLSRegressionStep
         
         """
-        rs = cls(d['model_expression'], d['tables'], out_fname=d['out_fname'], 
-                name=d['name'], tags=d['tags'])
-        rs.type = d['type']
+        # Pass values from the dictionary to the __init__() method
+        obj = cls(tables=d['tables'], model_expression=d['model_expression'], 
+                filters=d['filters'], out_tables=d['out_tables'], 
+                out_column=d['out_column'], out_transform=d['out_transform'],
+                out_filters=d['out_filters'], name=d['name'], tags=d['tags'])
+
+        obj.summary_table = d['summary_table']
+        obj.fitted_parameters = d['fitted_parameters']
         
         # Unpack the urbansim.models.RegressionModel() sub-object and resuscitate it
         model_config = yamlio.convert_to_yaml(d['model'], None)
-        rs.model = RegressionModel.from_yaml(model_config)
+        obj.model = RegressionModel.from_yaml(model_config)
         
-        return rs
+        return obj
         
     
     def to_dict(self):
         """
-        Create a dictionary representation of the object, for input/output.
+        Create a dictionary representation of the object.
         
         Returns
         -------
-        dictionary
+        dict
         
         """
-        d = {
-            'type': self.type,
-            'name': self.name,
-            'tags': self.tags,
-            'model_expression': self.model_expression,
-            'tables': self.tables,
-            'out_fname': self.out_fname,
+        d = TemplateStep.to_dict(self)
+        
+        # Add parameters not in parent class
+        d.update({
+            'summary_table': self.summary_table,
+            'fitted_parameters': self.fitted_parameters,
             'model': self.model.to_dict()  # urbansim.models.RegressionModel() sub-object
-        }
+        })
         return d
         
         
-    def get_data(self):
-        """
-        Generate a data table for estimation or prediction, from Orca table and column
-        names. The results should not be stored, in case the data in Orca changes.
-        
-        Returns
-        -------
-        DataFrame
-        
-        """
-        # TO DO: handle single table as well as list
-        tables = self.tables
-        columns = self.model.columns_used()
-        df = orca.merge_tables(target=tables[0], tables=tables, columns=columns)
-        return df
-
-
     def fit(self):
         """
         Fit the model; save and report results.
         
         """
         self.model = RegressionModel(model_expression=self.model_expression,
-                fit_filters=self.fit_filters, predict_filters=self.predict_filters,
-                ytransform=self.ytransform, name=self.name)
+                fit_filters=self.filters, predict_filters=self.out_filters,
+                ytransform=self.out_transform, name=self.name)
 
-        results = self.model.fit(self.get_data())
+        results = self.model.fit(self._get_data())
         
-        # TO DO: save the results table (as a string?) so we can display it again later
-        print(results.summary())
+        self.name = self._generate_name()
+        self.summary_table = str(results.summary())
+        print(self.summary_table)
+        
+        # We don't strictly need to save the fitted parameters, because they are also
+        # contained in the urbansim.models.RegressionModel() sub-object. But maintaining
+        # a parallel data structure to other templates will make it easier to refactor the
+        # code later on to not rely on RegressionModel any more. 
+        
+        self.fitted_parameters = results.params.tolist()
         
         
     def run(self):
         """
         Run the model step: calculate predicted values and use them to update a column.
         
+        The predicted values are written to Orca and also saved to the class object for 
+        interactive use (`predicted_values`, with type pd.Series). But they are not saved 
+        in the dictionary representation of the model step.
+        
         """
-        # TO DO: 
-        # - Figure out what we can infer about requirements for the underlying data, and
-        #   write an 'orca_test' assertion to confirm compliance.
-        # - If no destination column was specified, use name of dependent variable
+        # TO DO - figure out what we can infer about requirements for the underlying data
+        # and write an 'orca_test' assertion to confirm compliance.
 
-        values = self.model.predict(self.get_data())
-        print("Predicted " + str(len(values)) + " values")
+        values = self.model.predict(self._get_data('predict'))
+        self.predicted_values = values
         
-        dfw = orca.get_table(self.tables[0])
-        dfw.update_col_from_series(self.out_fname, values, cast=True)
+        colname = self._get_out_column()
+        tabname = self._get_out_table()
+
+        orca.get_table(tabname).update_col_from_series(colname, values, cast=True)
         
-    
-    @classmethod
-    def run_from_dict(cls, d):
-        """
-        Create and run a RegressionStep from a saved dictionary representation.
-        
-        GET RID OF THIS? BETTER TO JUST DO THE TWO STEPS EXPLICITLY
-                        
-        Parameters
-        ----------
-        d : dict
-        
-        """
-        rs = cls.from_dict(d)
-        rs.run()
-      
-    
-    def register(self):
-        """
-        Register the model step with Orca and the ModelManager. This includes saving it
-        to disk so it will be automatically loaded in the future. 
-        
-        """
-        d = self.to_dict()
-        mm.add_step(d)
-        
-        
-        
-        
+            
         

--- a/urbansim_templates/models/shared.py
+++ b/urbansim_templates/models/shared.py
@@ -36,11 +36,13 @@ class TemplateStep(object):
 
     """
     def __init__(self, tables=None, model_expression=None, filters=None, out_tables=None,
-            out_column=None, out_transform=None, out_filters=None, name=None, tags=None):
+            out_column=None, out_transform=None, out_filters=None, name=None, tags=[]):
         
         self.tables = tables
         self.model_expression = model_expression
         self.filters = filters
+        
+        # TO DO - out_transform might not belong here - is it only used for OLS?
         
         self.out_tables = out_tables
         self.out_column = out_column


### PR DESCRIPTION
This PR updates the OLS regression step template to match the functionality of binary logit:

- draws everything except constructor, `fit()`, and `run()` from the `TemplateStep()` parent class
- parameters can be added and edited at any time, `fit()` can be re-run at any time
- arguments are renamed to clearly distinguish estimation parameters from prediction parameters

Docstrings are in good shape; usage demonstration here: https://github.com/ual/urbansim_parcel_bayarea/blob/master/notebooks-sam/Demo.ipynb

This update will break previously saved OLS steps. I'm not intending to do this again, but to be safe we should save the notebooks used to generate model steps we like, in case they need to be re-run.

Overall status:
- OLS and binary logit templates are ready for use
- MNL (small choice set, large choice set) up next

@gboeing @emporter @mxndrwgrdnr @waddell 