### PR TITLE
Adding MNL template for small number of alternatives

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='urbansim_templates',
-    version='0.1.dev3',
+    version='0.1.dev4',
     description='UrbanSim extension for managing model steps',
     author='UrbanSim Inc.',
     author_email='info@urbansim.com',

--- a/urbansim_templates/modelmanager.py
+++ b/urbansim_templates/modelmanager.py
@@ -11,6 +11,7 @@ from .models import MNLDiscreteChoiceStep
 _STEPS = {}  # master repository of steps
 _STARTUP_QUEUE = {}  # steps waiting to be registered
 
+# TO DO - does this work in Windows?
 DISK_STORE = 'configs/modelmanager_configs.yaml'
 
 
@@ -23,6 +24,23 @@ def main():
     if (len(_STEPS) == 0):
         load_steps_from_disk()
     
+
+def get_config_directory():
+    """
+    Return the config directory, for other services that need to interoperate.
+    
+    TO DO - better way to do this?
+    
+    Returns
+    -------
+    str
+        Includes a trailing backslash
+    
+    """
+    # TO DO - handle case where DISK_STORE is just a file name, no directory path
+    
+    return '/'.join(DISK_STORE.split('/')[:-1]) + '/'
+
 
 def list_steps():
     """

--- a/urbansim_templates/modelmanager.py
+++ b/urbansim_templates/modelmanager.py
@@ -6,6 +6,7 @@ from urbansim.utils import yamlio
 from .models import OLSRegressionStep
 from .models import BinaryLogitStep
 from .models import MNLDiscreteChoiceStep
+from .models import SmallMultinomialLogitStep
 
 
 _STEPS = {}  # master repository of steps
@@ -25,7 +26,7 @@ def main():
         load_steps_from_disk()
     
 
-def get_config_directory():
+def get_config_dir():
     """
     Return the config directory, for other services that need to interoperate.
     

--- a/urbansim_templates/models/__init__.py
+++ b/urbansim_templates/models/__init__.py
@@ -2,3 +2,4 @@ from .binary_logit import BinaryLogitStep
 from .dcm import MNLDiscreteChoiceStep
 from .regression import OLSRegressionStep
 from .shared import TemplateStep
+from .small_multinomial_logit import SmallMultinomialLogitStep

--- a/urbansim_templates/models/binary_logit.py
+++ b/urbansim_templates/models/binary_logit.py
@@ -229,7 +229,7 @@ class BinaryLogitStep(TemplateStep):
         rand = np.random.random(len(probs))
         choices = np.less(rand, probs)
         
-        # Save choices...
+        # Save results to the class object (via df to include index)
         df['_probs'] = probs
         self.probabilities = df._probs
         df['_choices'] = choices

--- a/urbansim_templates/models/binary_logit.py
+++ b/urbansim_templates/models/binary_logit.py
@@ -246,7 +246,7 @@ class BinaryLogitStep(TemplateStep):
         if self.out_value_false is not 'nothing':
             df.loc[df._choices==False, colname] = self.out_value_false
         
-        orca.get_table(tabname).update_col_from_series(colname, df[colname])
+        orca.get_table(tabname).update_col_from_series(colname, df[colname], cast=True)
         
         
         

--- a/urbansim_templates/models/shared.py
+++ b/urbansim_templates/models/shared.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 
 import numpy as np
 import pandas as pd
+from collections import OrderedDict
 from datetime import datetime as dt
 
 import orca
@@ -170,14 +171,20 @@ class TemplateStep(object):
         DataFrame
         
         """
+        # TO DO - verify input data
         
-        # TO DO - verify tables and model_expression are not None
+        if isinstance(self.model_expression, str):
+            expr_cols = util.columns_in_formula(self.model_expression)
+        
+        # This is for PyLogit model expressions
+        elif isinstance(self.model_expression, OrderedDict):
+            # TO DO - check that this works in Python 2.7
+            expr_cols = [t[0] for t in list(self.model_expression.items()) \
+                         if t[0] is not 'intercept']
         
         if (task == 'fit'):
             tables = self.tables
-            columns = util.columns_in_formula(self.model_expression) \
-                    + util.columns_in_filters(self.filters)
-            
+            columns = expr_cols + util.columns_in_filters(self.filters)
             filters = self.filters
         
         elif (task == 'predict'):
@@ -186,9 +193,7 @@ class TemplateStep(object):
             else:
                 tables = self.tables
                 
-            columns = util.columns_in_formula(self.model_expression) \
-                    + util.columns_in_filters(self.out_filters)
-            
+            columns = expr_cols + util.columns_in_filters(self.out_filters)
             if self.out_column is not None:
                 columns += [self.out_column]
             

--- a/urbansim_templates/models/shared.py
+++ b/urbansim_templates/models/shared.py
@@ -182,6 +182,7 @@ class TemplateStep(object):
             expr_cols = [t[0] for t in list(self.model_expression.items()) \
                          if t[0] is not 'intercept']
             # TO DO - not very general, maybe we should just override the method
+            # TO DO - and this only applies to the fit condition
             if self.choice_column is not None:
                 expr_cols += [self.choice_column]
         

--- a/urbansim_templates/models/shared.py
+++ b/urbansim_templates/models/shared.py
@@ -181,6 +181,9 @@ class TemplateStep(object):
             # TO DO - check that this works in Python 2.7
             expr_cols = [t[0] for t in list(self.model_expression.items()) \
                          if t[0] is not 'intercept']
+            # TO DO - not very general, maybe we should just override the method
+            if self.choice_column is not None:
+                expr_cols += [self.choice_column]
         
         if (task == 'fit'):
             tables = self.tables

--- a/urbansim_templates/models/small_multinomial_logit.py
+++ b/urbansim_templates/models/small_multinomial_logit.py
@@ -1,0 +1,163 @@
+from __future__ import print_function
+
+import numpy as np
+import pandas as pd
+
+import orca
+
+from .shared import TemplateStep
+from .. import modelmanager as mm
+
+
+class SmallMultinomialLogitStep(TemplateStep):
+    """
+    A class for building multinomial logit model steps where the number of alternatives is
+    "small". Estimation is handled by ChoiceModels and PyLogit. Simulation is handled by
+    PyLogit and within this class. 
+    
+    Multinomial Logit models can involve a range of different specification and estimation
+    mechanics. For now these are separated into two templates. What's the difference?
+    
+    "Small" MNL:
+    - data is in a single table (choosers)
+    - each alternative can have a different model expression
+    - all the alternatives are available to all choosers
+    - estimation and simulation use the PyLogit engine (via ChoiceModels)
+    
+    "Large" MNL:
+    - data is in two tables (choosers and alternatives)
+    - each alternative has the same model expression
+    - N alternatives are sampled for each chooser
+    - estimation and simulation use the ChoiceModels engine (formerly UrbanSim MNL)
+    
+    TO DO:
+    - Add support for sampling weights
+    - Add support for on-the-fly interaction calculations (e.g. distance)
+    - Add support for special columns in the choosers table for things like availability 
+      of alternatives or alternative-specific data values? Not sure we need this on top of
+      model expressions that vary by alternative. But we could implement it pretty easily
+      using PyLogit's `choicetools.convert_wide_to_long()`.
+    
+    Parameters
+    ----------
+    tables
+    model_expression : OrderedDict, optional
+    model_labels : OrderedDict, optional
+        NEW
+    choice_col : str
+        NEW
+    initial_coefs : float, list, or 1D array, optional
+        NEW
+    filters
+    out_tables
+    out_column
+    out_filters
+    name
+    tags
+    
+    """
+    def __init__(self, tables=None, model_expression=None, model_labels=None,
+            choice_col=None, initial_coefs=None, filters=None, out_tables=None,
+            out_column=None, out_filters=None, name=None, tags=[]):
+        
+        # Parent class can initialize the standard parameters
+        TemplateStep.__init__(self, tables=tables, model_expression=model_expression, 
+                filters=filters, out_tables=out_tables, out_column=out_column, 
+                out_transform=None, out_filters=out_filters, name=name, tags=tags)
+        
+        # Custom parameters not in parent class
+        self.model_labels = model_labels
+        self.choice_col = choice_col
+        self.initial_coefs = initial_coefs
+        
+        # Placeholders for model fit data, filled in by fit() or from_dict()
+        self.summary_table = None 
+        self.model = None
+
+    
+    @classmethod
+    def from_dict(cls, d):
+        """
+        Create an object instance from a saved dictionary representation.
+        
+        Parameters
+        ----------
+        d : dict
+        
+        Returns
+        -------
+        SmallMultinomialLogitStep
+        
+        """
+        # TO DO - FILL THIS IN
+        
+        # Pass values from the dictionary to the __init__() method
+        obj = cls(tables=d['tables'], model_expression=d['model_expression'], 
+                filters=d['filters'], out_tables=d['out_tables'], 
+                out_column=d['out_column'], out_filters=d['out_filters'], 
+                out_value_true=d['out_value_true'], out_value_false=d['out_value_false'], 
+                name=d['name'], tags=d['tags'])
+                
+        obj.summary_table = d['summary_table']
+        obj.fitted_parameters = d['fitted_parameters']
+        
+        return obj
+        
+        # TO DO - check that this is re-creating OrderedDicts properly
+        # TO DO - read pickled version of the model
+
+
+    def to_dict(self):
+        """
+        Create a dictionary representation of the object.
+        
+        Returns
+        -------
+        dict
+        
+        """
+        d = TemplateStep.to_dict(self)
+        
+        # Add parameters not in parent class
+        d.update({
+            'model_labels': self.model_labels,
+            'choice_col': self.choice_col,
+            'initial_coefs': self.initial_coefs,
+            'summary_table': self.summary_table
+        })
+        return d
+        
+        # TO DO - check that the OrderedDicts are stored properly
+        # TO DO - store pickled version of the model
+    
+    
+    def fit(self):
+        """
+        Fit the model; save an report results.
+        
+        """
+        # Get column names out of OrderedDict
+        
+        # Get data
+        
+        # Convert to long format
+        
+        # Pass to ChoiceModels
+        
+        # Save the underlying model
+
+
+    def run(self):
+        """
+        
+        """
+        # Get predictions from underlying model
+        
+        # Save them to Orca
+
+
+
+
+
+
+


### PR DESCRIPTION
This PR adds a multinomial logit template for cases like travel mode choice, where the number of alternatives is small and we want to specify different utility functions for them. 

````
"Small" MNL:
- data is in a single table (choosers)
- each alternative can have a different model expression
- all the alternatives are available to all choosers
- estimation and simulation use the PyLogit engine (via ChoiceModels)
    
"Large" MNL:
- data is in two tables (choosers and alternatives)
- each alternative has the same model expression
- N alternatives are sampled for each chooser
- estimation and simulation use the ChoiceModels engine (formerly UrbanSim MNL)
````

This template ended up requiring a lot of custom code. Model estimation and predicted probabilities come from PyLogit via ChoiceModels, while data manipulation, Monte Carlo simulation of choices, and saving/loading of PyLogit parameters is handled by the template. Portions of the template code should move to ChoiceModels.

It does not yet support specifying availability of alternatives. (I know this is not ideal, but it seemed better to get the other functionality done. For now, just include the variables you would use to predict availability in the alternative's utility function.)

Docstrings are in good shape; usage demo here:
https://github.com/ual/urbansim_parcel_bayarea/blob/sam/notebooks-sam/MNL-demo.ipynb

@gboeing @emporter @mxndrwgrdnr @waddell