### PR TITLE
Add version tracking

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='urbansim_templates',
-    version='0.1.dev4',
+    version='0.1.dev5',
     description='UrbanSim extension for managing model steps',
     author='UrbanSim Inc.',
     author_email='info@urbansim.com',

--- a/urbansim_templates/modelmanager.py
+++ b/urbansim_templates/modelmanager.py
@@ -9,6 +9,8 @@ from .models import LargeMultinomialLogitStep
 from .models import SmallMultinomialLogitStep
 
 
+MODELMANAGER_VERSION = '0.1dev5'
+
 _STEPS = {}  # master repository of steps
 _STARTUP_QUEUE = {}  # steps waiting to be registered
 
@@ -63,9 +65,9 @@ def list_steps():
 
 def add_step(d):
     """
-    Register a model step from a dictionary representation conforming to UrbanSim 
-    YAML spec v0.2. This will override any previously registered step with the same 
-    name. The step will be registered with Orca and written to persistent storage.
+    Register a model step from a dictionary representation. This will override any 
+    previously registered step with the same name. The step will be registered with Orca 
+    and written to persistent storage.
     
     Parameters
     ----------
@@ -82,6 +84,10 @@ def add_step(d):
     # service. Another approach would be to require users to import all the templates
     # they'll be using, before importing `modelmanager`. Then we can look them up using
     # `globals()[class_name]`. Safer, but less convenient. Must be other solutions too.
+    
+    reserved_names = ['modelmanager_version']
+    if (d['name'] in reserved_names):
+        raise ValueError('cannot be registered with ModelManager because "%s" is a reserved name' % (d['name']))
     
     if (d['name'] in _STEPS):
         remove_step(d['name'])
@@ -139,7 +145,9 @@ def save_steps_to_disk():
     Save current representation of model steps to disk, over-writing the previous file.
     
     """
-    yamlio.convert_to_yaml(_STEPS, DISK_STORE)
+    content = {'modelmanager_version': MODELMANAGER_VERSION}.update(_STEPS)
+    
+    yamlio.convert_to_yaml(content, DISK_STORE)
     
     
 def load_steps_from_disk():

--- a/urbansim_templates/modelmanager.py
+++ b/urbansim_templates/modelmanager.py
@@ -87,7 +87,7 @@ def add_step(d):
     
     reserved_names = ['modelmanager_version']
     if (d['name'] in reserved_names):
-        raise ValueError('cannot be registered with ModelManager because "%s" is a reserved name' % (d['name']))
+        raise ValueError('Step cannot be registered with ModelManager because "%s" is a reserved name' % (d['name']))
     
     if (d['name'] in _STEPS):
         remove_step(d['name'])
@@ -145,7 +145,11 @@ def save_steps_to_disk():
     Save current representation of model steps to disk, over-writing the previous file.
     
     """
-    content = {'modelmanager_version': MODELMANAGER_VERSION}.update(_STEPS)
+    headers = {'modelmanager_version': MODELMANAGER_VERSION}
+    body = _STEPS
+    
+    content = headers
+    content.update(body)
     
     yamlio.convert_to_yaml(content, DISK_STORE)
     
@@ -159,10 +163,12 @@ def load_steps_from_disk():
     # are finished before saving back to disk. Is there a better approach?
     
     _STARTUP_QUEUE = yamlio.yaml_to_dict(str_or_buffer=DISK_STORE)
+    reserved_names = ['modelmanager_version']
     
     while (len(_STARTUP_QUEUE) > 0):
         key, value = _STARTUP_QUEUE.popitem()
-        add_step(value)
+        if (key not in reserved_names):
+            add_step(value)
     
 
 main()

--- a/urbansim_templates/models/binary_logit.py
+++ b/urbansim_templates/models/binary_logit.py
@@ -253,4 +253,17 @@ class BinaryLogitStep(TemplateStep):
         orca.get_table(tabname).update_col_from_series(colname, df[colname], cast=True)
         
         
+    def register(self):
+        """
+        Register the model step with Orca and the ModelManager. This includes saving it
+        to disk so it can be automatically loaded in the future. 
         
+        Registering a step will rewrite any previously saved step with the same name. 
+        (If a custom name has not been provided, one is generated each time the `fit()` 
+        method runs.)
+                
+        """
+        d = self.to_dict()
+        mm.add_step(d)
+
+     

--- a/urbansim_templates/models/binary_logit.py
+++ b/urbansim_templates/models/binary_logit.py
@@ -12,6 +12,8 @@ from .shared import TemplateStep
 from .. import modelmanager as mm
 
 
+TEMPLATE_VERSION = '0.1dev1'
+
 class BinaryLogitStep(TemplateStep):
     """
     A class for building binary logit model steps. This extends TemplateStep, where some
@@ -97,6 +99,8 @@ class BinaryLogitStep(TemplateStep):
         TemplateStep.__init__(self, tables=tables, model_expression=model_expression, 
                 filters=filters, out_tables=out_tables, out_column=out_column, 
                 out_transform=None, out_filters=out_filters, name=name, tags=tags)
+        
+        self.version = TEMPLATE_VERSION
         
         # Custom parameters not in parent class
         self.out_value_true = out_value_true

--- a/urbansim_templates/models/large_multinomial_logit.py
+++ b/urbansim_templates/models/large_multinomial_logit.py
@@ -14,6 +14,8 @@ from .shared import TemplateStep
 from .. import modelmanager as mm
 
 
+TEMPLATE_VERSION = '0.1dev1'
+
 class LargeMultinomialLogitStep(TemplateStep):
     """
     A class for building multinomial logit model steps where the number of alternatives is
@@ -123,6 +125,8 @@ class LargeMultinomialLogitStep(TemplateStep):
                 filters=None, out_tables=None, out_column=out_column, out_transform=None, 
                 out_filters=None, name=name, tags=tags)
 
+        self.version = TEMPLATE_VERSION
+        
         # Custom parameters not in parent class
         self.choosers = choosers
         self.alternatives = alternatives

--- a/urbansim_templates/models/large_multinomial_logit.py
+++ b/urbansim_templates/models/large_multinomial_logit.py
@@ -362,3 +362,16 @@ class LargeMultinomialLogitStep(TemplateStep):
         dfw.update_col_from_series(self.out_fname, values, cast=True)
         
     
+    def register(self):
+        """
+        Register the model step with Orca and the ModelManager. This includes saving it
+        to disk so it can be automatically loaded in the future. 
+        
+        Registering a step will rewrite any previously saved step with the same name. 
+        (If a custom name has not been provided, one is generated each time the `fit()` 
+        method runs.)
+                
+        """
+        d = self.to_dict()
+        mm.add_step(d)
+

--- a/urbansim_templates/models/regression.py
+++ b/urbansim_templates/models/regression.py
@@ -198,5 +198,18 @@ class OLSRegressionStep(TemplateStep):
 
         orca.get_table(tabname).update_col_from_series(colname, values, cast=True)
         
+
+    def register(self):
+        """
+        Register the model step with Orca and the ModelManager. This includes saving it
+        to disk so it can be automatically loaded in the future. 
+        
+        Registering a step will rewrite any previously saved step with the same name. 
+        (If a custom name has not been provided, one is generated each time the `fit()` 
+        method runs.)
+                
+        """
+        d = self.to_dict()
+        mm.add_step(d)
             
         

--- a/urbansim_templates/models/regression.py
+++ b/urbansim_templates/models/regression.py
@@ -12,7 +12,7 @@ from .shared import TemplateStep
 from .. import modelmanager as mm
 
 
-TEMPLATE_VERSION = '0.1'
+TEMPLATE_VERSION = '0.1dev1'
 
 class OLSRegressionStep(TemplateStep):
     """
@@ -96,6 +96,8 @@ class OLSRegressionStep(TemplateStep):
                 filters=filters, out_tables=out_tables, out_column=out_column, 
                 out_transform=out_transform, out_filters=out_filters, name=name, 
                 tags=tags)
+        
+        self.version = TEMPLATE_VERSION
         
         # Placeholders for model fit data, filled in by fit() or from_dict()
         self.summary_table = None 

--- a/urbansim_templates/models/regression.py
+++ b/urbansim_templates/models/regression.py
@@ -12,6 +12,8 @@ from .shared import TemplateStep
 from .. import modelmanager as mm
 
 
+TEMPLATE_VERSION = '0.1'
+
 class OLSRegressionStep(TemplateStep):
     """
     A class for building OLS (ordinary least squares) regression model steps. This extends 

--- a/urbansim_templates/models/shared.py
+++ b/urbansim_templates/models/shared.py
@@ -93,7 +93,7 @@ class TemplateStep(object):
         """
         d = {
             'type': self.type,
-            #'version': self.version,
+            'version': self.version,
             'name': self.name,
             'tags': self.tags,
             'tables': self.tables,

--- a/urbansim_templates/models/shared.py
+++ b/urbansim_templates/models/shared.py
@@ -93,6 +93,7 @@ class TemplateStep(object):
         """
         d = {
             'type': self.type,
+            #'version': self.version,
             'name': self.name,
             'tags': self.tags,
             'tables': self.tables,

--- a/urbansim_templates/models/shared.py
+++ b/urbansim_templates/models/shared.py
@@ -280,16 +280,10 @@ class TemplateStep(object):
             return self.name
 
     
-    def run(self):
-        """
-        Execute the model step. Child classes are required to implement this method.
-        
-        """
-        return
-        
-    
     def register(self):
         """
+        DEPRECATED - BETTER IF MOVED TO CHILD CLASSES
+        
         Register the model step with Orca and the ModelManager. This includes saving it
         to disk so it can be automatically loaded in the future. 
         

--- a/urbansim_templates/models/shared.py
+++ b/urbansim_templates/models/shared.py
@@ -279,18 +279,3 @@ class TemplateStep(object):
         else:
             return self.name
 
-    
-    def register(self):
-        """
-        DEPRECATED - BETTER IF MOVED TO CHILD CLASSES
-        
-        Register the model step with Orca and the ModelManager. This includes saving it
-        to disk so it can be automatically loaded in the future. 
-        
-        Registering a step will rewrite any previously saved step with the same name. 
-        (If a custom name has not been provided, one is generated each time the `fit()` 
-        method runs.)
-                
-        """
-        d = self.to_dict()
-        mm.add_step(d)

--- a/urbansim_templates/models/small_multinomial_logit.py
+++ b/urbansim_templates/models/small_multinomial_logit.py
@@ -389,3 +389,16 @@ class SmallMultinomialLogitStep(TemplateStep):
         orca.get_table(tabname).update_col_from_series(colname, df._choices, cast=True)
 
 
+    def register(self):
+        """
+        Register the model step with Orca and the ModelManager. This includes saving it
+        to disk so it can be automatically loaded in the future. 
+        
+        Registering a step will rewrite any previously saved step with the same name. 
+        (If a custom name has not been provided, one is generated each time the `fit()` 
+        method runs.)
+                
+        """
+        d = self.to_dict()
+        mm.add_step(d)
+

--- a/urbansim_templates/models/small_multinomial_logit.py
+++ b/urbansim_templates/models/small_multinomial_logit.py
@@ -13,6 +13,8 @@ from .shared import TemplateStep
 from .. import modelmanager as mm
 
 
+TEMPLATE_VERSION = '0.1dev1'
+
 class SmallMultinomialLogitStep(TemplateStep):
     """
     A class for building multinomial logit model steps where the number of alternatives is
@@ -106,6 +108,8 @@ class SmallMultinomialLogitStep(TemplateStep):
         TemplateStep.__init__(self, tables=tables, model_expression=model_expression, 
                 filters=filters, out_tables=out_tables, out_column=out_column, 
                 out_transform=None, out_filters=out_filters, name=name, tags=tags)
+        
+        self.version = TEMPLATE_VERSION
         
         # Custom parameters not in parent class
         self.model_labels = model_labels


### PR DESCRIPTION
This PR adds version tracking to model steps' dictionary (and YAML) representations. 

Stored model step instances now include both the model manager codebase version (at the file level) and the template codebase version (at the model step level).

The rationale for this is that eventually we'll need/want to make changes that introduce incompatibilities with older versions of saved model steps. Tracking which version of the codebase created a saved model step will help us deal with updating and conversion.

This PR also moves the `register()` method out of the template parent class and into the individual templates, which resolves some bugs. 