### PR TITLE
Updating large MNL to provide probabilities and unconstrained choices

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
     install_requires=[
         'numpy >= 1.14',
         'orca >= 1.4',
+        'pandana >= 0.3',
         'pandas >= 0.22',
         'statsmodels >= 0.8',
         'urbansim >= 3.1.1'

--- a/urbansim_templates/models/large_multinomial_logit.py
+++ b/urbansim_templates/models/large_multinomial_logit.py
@@ -255,7 +255,7 @@ class LargeMultinomialLogitStep(TemplateStep):
         
         else:
             alternatives = self._get_df(tables = self.alternatives, 
-                                        filters = self.alternative_filters)
+                                        filters = self.alt_filters)
             
             n_minus_1 = len(alternatives) - 1
             return n_minus_1
@@ -277,7 +277,7 @@ class LargeMultinomialLogitStep(TemplateStep):
         chosen = observations[self.choice_column]
         
         alternatives = self._get_df(tables = self.alternatives, 
-                                    filters = self.alternative_filters)
+                                    filters = self.alt_filters)
         
         data = MergedChoiceTable(observations = observations,
                                  alternatives = alternatives,
@@ -304,10 +304,10 @@ class LargeMultinomialLogitStep(TemplateStep):
         Inconveniently, `choicemodels.mnl.mnl_simulate()` identifies choices by position
         rather than id. This function converts them. It should move to ChoiceModels.
         
-        We observe N choice scenarios. In each, one of J alternatives is chosen.
-        We have a long (len N * J) list of the available alternatives. We have a 
-        list (len N) of which alternatives were chosen, but it identifies them 
-        by POSITION and we want their ID.    
+        We observe N choice scenarios. In each, one of J alternatives is chosen. We have a 
+        long (len N * J) list of the available alternatives. We have a list (len N) of 
+        which alternatives were chosen, but it identifies them by POSITION and we want 
+        their ID.    
     
         Parameters
         ----------
@@ -316,12 +316,12 @@ class LargeMultinomialLogitStep(TemplateStep):
         
         positions : list or list-like
             List of chosen alternatives by position (len N), where each entry is
-            an int in range [0, J)
+            an int in range [0, J).
     
         Returns
         -------
         chosen_ids : list
-            List of chosen alternatives by ID (len N)
+            List of chosen alternatives by ID (len N).
     
         """
         N = len(positions)
@@ -335,8 +335,7 @@ class LargeMultinomialLogitStep(TemplateStep):
         """
         Run the model step: calculate simulated choices and use them to update a column.
         
-        Predicted probabilities and choices come from ChoiceModels (currently we use
-        the UrbanSim MNL functions directly).
+        Predicted probabilities and simulated choices come from ChoiceModels.
         
         The predicted probabilities and simulated choices are saved to the class object 
         for interactive use (`probabilities` with type pd.DataFrame, and `choices` with 
@@ -369,8 +368,9 @@ class LargeMultinomialLogitStep(TemplateStep):
         
         choices = self._get_chosen_ids(dm.index.tolist(), choice_positions)
         
-        # Save results to the class object
-        self.choices = choices
+        # Save results to the class object (via df to include indexes)
+        dm['_choices'] = choices
+        self.choices = dm._choices
         
         # Update Orca    
     

--- a/urbansim_templates/models/large_multinomial_logit.py
+++ b/urbansim_templates/models/large_multinomial_logit.py
@@ -339,7 +339,9 @@ class LargeMultinomialLogitStep(TemplateStep):
         """
         Run the model step: calculate simulated choices and use them to update a column.
         
-        Predicted probabilities and simulated choices come from ChoiceModels.
+        Predicted probabilities and simulated choices come from ChoiceModels. For now, 
+        the choices are unconstrained (any number of choosers can select the same 
+        alternative).
         
         The predicted probabilities and simulated choices are saved to the class object 
         for interactive use (`probabilities` with type pd.DataFrame, and `choices` with 
@@ -401,31 +403,6 @@ class LargeMultinomialLogitStep(TemplateStep):
         print("Warning: choices are unconstrained; additional functionality in progress")
     
 
-    def run_deprecated(self):
-        """
-        THIS METHOD IS DEPRECATED.
-                
-        Run the model step: calculate predicted values and use them to update a column.
-        
-        """
-        # TO DO: 
-        # - Figure out what we can infer about requirements for the underlying data, and
-        #   write an 'orca_test' assertion to confirm compliance.
-        # - If no destination column was specified, use name of dependent variable
-
-        choosers = orca.get_table(self.choosers).to_frame()
-        
-        # TO DO - fix to work with single table of alternatives
-        alternatives = orca.merge_tables(
-            tables=self.alternatives, target=self.alternatives[0])
-
-        values = self.model.predict(choosers, alternatives)
-        print("Predicted " + str(len(values)) + " values")
-        
-        dfw = orca.get_table(self.choosers)
-        dfw.update_col_from_series(self.out_fname, values, cast=True)
-        
-    
     def register(self):
         """
         Register the model step with Orca and the ModelManager. This includes saving it

--- a/urbansim_templates/models/large_multinomial_logit.py
+++ b/urbansim_templates/models/large_multinomial_logit.py
@@ -365,20 +365,26 @@ class LargeMultinomialLogitStep(TemplateStep):
         dm = patsy.dmatrix(self.model_expression, data=data.to_frame(), 
                            return_type='dataframe')
         
-        # Get choices (TO DO - get probabilities too)
+        # Get probabilities and choices
+        probs = mnl.mnl_simulate(data = dm, coeff = self.fitted_parameters, 
+                                            numalts = numalts, returnprobs=True)
+
+        # TO DO - this has to recalculate the probabilities because there's not currently 
+        # a code path to get both at once! - fix this)
         choice_positions = mnl.mnl_simulate(data = dm, coeff = self.fitted_parameters, 
                                             numalts = numalts, returnprobs=False)
         
-        print(data.alternative_id_col)
         ids = data.to_frame()[data.alternative_id_col].tolist()
-        print(ids[:20])
         choices = self._get_chosen_ids(ids, choice_positions)
         
         # Save results to the class object (via df to include indexes)
+        self.probabilities = probs
         observations['_choices'] = choices
         self.choices = observations._choices
         
-        # Update Orca    
+        # Update Orca
+        
+        # Print a message about limited usage
     
 
     def run_deprecated(self):

--- a/urbansim_templates/models/shared.py
+++ b/urbansim_templates/models/shared.py
@@ -198,6 +198,8 @@ class TemplateStep(object):
     
     def _get_data(self, task='fit'):
         """
+        DEPRECATED - this should be replaced by the more general _get_df()
+        
         Generate a data table for estimation or prediction, relying on functionality from
         Orca and UrbanSim.models.util. This should be performed immediately before 
         estimation or prediction so that it reflects the current data state.

--- a/urbansim_templates/models/shared.py
+++ b/urbansim_templates/models/shared.py
@@ -106,7 +106,7 @@ class TemplateStep(object):
         return d
     
     
-    def _normalize_table_param(tables):
+    def _normalize_table_param(self, tables):
         """
         Normalize table parameter input. TO DO - add more type validation
         
@@ -140,7 +140,7 @@ class TemplateStep(object):
         self.__out_tables = self._normalize_table_param(out_tables)
 
 
-    def _get_df(self, tables=self.tables, fallback_tables=None, filters=self.filters,
+    def _get_df(self, tables='unset', fallback_tables=None, filters='unset',
             model_expression=None):
         """
         Generate a data table for estimation or prediction, relying on functionality from
@@ -177,8 +177,14 @@ class TemplateStep(object):
         DataFrame
         
         """
+        if tables == 'unset':
+            tables = self.tables
+        
         if tables is None:
             tables = fallback_tables
+            
+        if filters == 'unset':
+            filters = self.filters
         
         if isinstance(tables, list):
             df = orca.merge_tables(target=tables[0], tables=tables)

--- a/urbansim_templates/models/shared.py
+++ b/urbansim_templates/models/shared.py
@@ -106,52 +106,89 @@ class TemplateStep(object):
         return d
     
     
+    def _normalize_table_param(tables):
+        """
+        Normalize table parameter input. TO DO - add more type validation
+        
+        """
+        if isinstance(tables, list):
+            # Normalize [] to None
+            if len(tables) == 0:
+                return None
+        
+            # Normalize [str] to str
+            if len(tables) == 1:
+                return tables[0]
+                
+        return tables
+    
+    
     @property
     def tables(self):
         return self.__tables
         
-
     @tables.setter
     def tables(self, tables):
-        """
-        Normalize storage of the 'tables' property. TO DO - add type validation?
-        
-        """
-        self.__tables = tables
-        
-        if isinstance(tables, list):
-            # Normalize [] to None
-            if len(tables) == 0:
-                self.__tables = None
+        self.__tables = self._normalize_table_param(tables)
             
-            # Normalize [str] to str
-            if len(tables) == 1:
-                self.__tables = tables[0]
-            
-    
     @property
     def out_tables(self):
         return self.__out_tables
         
-
     @out_tables.setter
     def out_tables(self, out_tables):
+        self.__out_tables = self._normalize_table_param(out_tables)
+
+
+    def _get_df(self, tables=self.tables, fallback_tables=None, filters=self.filters,
+            model_expression=None):
         """
-        Normalize storage of the 'out_tables' property. TO DO - add type validation?
+        Generate a data table for estimation or prediction, relying on functionality from
+        Orca and `urbansim.models.util`. This should be performed immediately before
+        estimation or prediction so that it reflects the current data state.
         
-        """
-        self.__out_tables = out_tables
+        The output includes only the necessary columns: those mentioned in the model 
+        expression or filters, plus (it appears) the index of each merged table. Relevant
+        row filters are also applied.
         
-        if isinstance(out_tables, list):
-            # Normalize [] to None
-            if len(out_tables) == 0:
-                self.__out_tables = None
+        TO DO - this method is a generalization of _get_data(), and should replace it, 
+        but does not currently support column filtering or PyLogit model expressions.
+        
+        Parameters
+        ----------
+        tables : str or list of str, optional
+            Name of table or tables. If not provided, `self.tables` will be used.
+        
+        fallback_tables : str or list of str, optional
+            Table(s) to use if first argument evaluates to `None`.
             
-            # Normalize [str] to str
-            if len(out_tables) == 1:
-                self.__out_tables = out_tables[0]
-
-
+        filters : str or list of str, optional
+            Filter(s) to apply. If not provided, `self.filters` will be used.
+            
+        model_expression : NOT YET IMPLEMENTED
+            Model expression, for determining which columns are needed. If not provided,
+            `self.model_expression` will be used.
+            
+            TO DO - this needs to handle the large MNL case where there are two sets of
+            data tables, so we can't use urbansim.models.util.columns_in_formula()
+        
+        Returns
+        -------
+        DataFrame
+        
+        """
+        if tables is None:
+            tables = fallback_tables
+        
+        if isinstance(tables, list):
+            df = orca.merge_tables(target=tables[0], tables=tables)
+        else:
+            df = orca.get_table(tables).to_frame()
+        
+        df = util.apply_filter_query(df, filters)
+        return df
+        
+    
     def _get_data(self, task='fit'):
         """
         Generate a data table for estimation or prediction, relying on functionality from
@@ -214,6 +251,8 @@ class TemplateStep(object):
 
     def _get_filter_columns(self):
         """
+        THIS METHOD DOES NOT WORK YET.   
+        
         Return list of column names referenced in the filters.
         
         """

--- a/urbansim_templates/models/small_multinomial_logit.py
+++ b/urbansim_templates/models/small_multinomial_logit.py
@@ -332,7 +332,7 @@ class SmallMultinomialLogitStep(TemplateStep):
 
     def run(self):
         """
-        Run the model step; calculate simulated choices and use them to update a column.
+        Run the model step: calculate simulated choices and use them to update a column.
         
         Alternatives that appear in the estimation data but not in the model expression
         will not be available for simulation.
@@ -344,7 +344,7 @@ class SmallMultinomialLogitStep(TemplateStep):
         for interactive use (`probabilities` with type pd.DataFrame, and `choices` with 
         type pd.Series) but are not persisted in the dictionary representation of the 
         model step.
-                
+        
         """
         df = self._get_data('predict')
         long_df = self._to_long(df, 'predict')


### PR DESCRIPTION
This PR updates the `LargeMultinomialLogitStep` template to provide probabilities and unconstrained choices when a fitted model is run.

Demonstration here: [Large-MNL-work.ipynb](https://github.com/ual/urbansim_parcel_bayarea/blob/0f15e5679e5ac89dd74fbc50790588ffca2538c2/notebooks-sam/Large-MNL-work.ipynb)

In most cases we will actually want _constrained_ choices, which are not yet implemented. See https://github.com/UDST/choicemodels/issues/26 for a discussion.

cc @waddell @Arezoo-bz @mxndrwgrdnr 