### PR TITLE
Explicit initialization and multiple config files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='urbansim_templates',
-    version='0.1.dev6',
+    version='0.1.dev7',
     description='UrbanSim extension for managing model steps',
     author='UrbanSim Inc.',
     author_email='info@urbansim.com',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='urbansim_templates',
-    version='0.1.dev7',
+    version='0.1.dev8',
     description='UrbanSim extension for managing model steps',
     author='UrbanSim Inc.',
     author_email='info@urbansim.com',

--- a/urbansim_templates/modelmanager.py
+++ b/urbansim_templates/modelmanager.py
@@ -12,7 +12,7 @@ from .models import LargeMultinomialLogitStep
 from .models import SmallMultinomialLogitStep
 
 
-MODELMANAGER_VERSION = '0.1.dev7'
+MODELMANAGER_VERSION = '0.1.dev8'
 
 _STEPS = {}  # master repository of steps
 _STARTUP_QUEUE = {}  # steps waiting to be registered

--- a/urbansim_templates/modelmanager.py
+++ b/urbansim_templates/modelmanager.py
@@ -68,23 +68,6 @@ def initialize(path='configs'):
         add_step(d['saved_object'], save_to_disk=False)    
 
 
-def get_config_dir():
-    """
-    Return the config directory, for other services that need to interoperate.
-    
-    TO DO - better way to do this?
-    
-    Returns
-    -------
-    str
-        Includes a trailing backslash
-    
-    """
-    # TO DO - handle case where DISK_STORE is just a file name, no directory path
-    
-    return '/'.join(_DISK_STORE.split('/')[:-1]) + '/'
-
-
 def list_steps():
     """
     Return a list of registered steps, with name, type, and tags for each.
@@ -201,3 +184,15 @@ def remove_step(name):
     
     os.remove(os.path.join(_DISK_STORE, name+'.yaml'))
     
+
+def get_config_dir():
+    """
+    Return the config directory, for other services that need to interoperate.
+    
+    Returns
+    -------
+    str
+    
+    """
+    return _DISK_STORE
+

--- a/urbansim_templates/modelmanager.py
+++ b/urbansim_templates/modelmanager.py
@@ -53,7 +53,9 @@ def initialize(path='configs'):
     for f in files:
         d = yamlio.yaml_to_dict(str_or_buffer=f)
         if 'modelmanager_version' in d:
-            # TO DO - fix to work with future versions too
+            # TO DO 
+            # - fix to work with future versions too
+            # - check that file name matches object name in the file (and warn if not?)
             if d['modelmanager_version'] == '0.1.dev8':
                 steps.append(d)            
     

--- a/urbansim_templates/models/small_multinomial_logit.py
+++ b/urbansim_templates/models/small_multinomial_logit.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 
 from collections import OrderedDict
+import os
 import pickle
 
 import numpy as np
@@ -209,7 +210,7 @@ class SmallMultinomialLogitStep(TemplateStep):
         
         # Store a pickled version of the PyLogit fitted model
         if self.model is not None:
-            self.model.to_pickle(mm.get_config_dir() + self.name + '.pkl')
+            self.model.to_pickle(os.path.join(mm.get_config_dir(), self.name+'.pkl'))
         
         return d
     


### PR DESCRIPTION
This PR changes the initialization behavior of the library, enables custom locations for saved model steps, and switches to using separate files for each saved object. This is a disruptive set of changes, but should improve usability and pave the way for future features. This is discussed in Issue #16.

- API documentation is in the docstrings: [modelmanager.py](https://github.com/UDST/urbansim_templates/blob/f2e849efe0dab0afd40f88d23e8ba6e5af5fd16f/urbansim_templates/modelmanager.py)
- demonstration of new features: [Initialization.ipynb](https://github.com/ual/urbansim_parcel_bayarea/blob/9be8ea11a46d781ac1c98fd41e6aa4bd658ed4e1/notebooks-sam/Initialization.ipynb)
- new config format: [model-step-name.yaml](https://github.com/ual/urbansim_parcel_bayarea/blob/9be8ea11a46d781ac1c98fd41e6aa4bd658ed4e1/configs/large-mnl-test.yaml)
- old config format: [modelmanager_configs.yaml](https://github.com/ual/urbansim_parcel_bayarea/blob/70bf3b845644a6ad4b7feaad89196ec14e74a273/configs/modelmanager_configs.yaml)

### Functionality
#### Explicit initialization

- importing the library no longer automatically loads saved steps
- new usage: `mm.initialize()`

#### Custom locations

- `./configs` remains the default location for saved steps
- use `mm.initialize('path')` to set a custom location

#### One file per saved object

- old behavior was to store all the saved steps in `modelmanager_configs.yaml`
- new behavior is to save each saved object in a file named `<model-step-name>.yaml`

#### Other changes

- adds status messages for most ModelManager operations

#### Versioning

- bumps package version to 0.1.dev8 in `setup.py`
- bumps MODELMANAGER_VERSION to 0.1.dev8
- individual template versions unchanged

### Migration

1. No migration is needed until you run `git pull` to update `urbansim_templates` (old versions will ignore the new yaml files, and the new version will ignore old yaml files)

2. Notebooks need to add a line for `mm.initialize()` after importing the library

3. Existing saved model steps need to be manually copied to new files (see examples above):

- copy and paste first line of `modelmanager_configs.yaml` plus one top-level object
- change version number in first line to `0.1.dev8`
- change object label from the name to `saved_object`
- name the file `<object-name>.yaml`