### PR TITLE
Saving estimation data table to Large MNL class object

### DIFF
--- a/urbansim_templates/models/large_multinomial_logit.py
+++ b/urbansim_templates/models/large_multinomial_logit.py
@@ -273,6 +273,10 @@ class LargeMultinomialLogitStep(TemplateStep):
         The `fit()` method can be run as many times as desired. Results will not be saved
         with Orca or ModelManager until the `register()` method is run.
         
+        After sampling alternatives for each chooser, the merged choice table is saved to 
+        the class object for diagnostic use (`mergedchoicetable` with type
+        choicemodels.tools.MergedChoiceTable).
+        
         """
         # TO DO - update choicemodels to accept a column name for chosen alts
         observations = self._get_df(tables=self.choosers, 
@@ -301,6 +305,9 @@ class LargeMultinomialLogitStep(TemplateStep):
         # For now, just save the summary table and fitted parameters
         coefs = results.get_raw_results()['fit_parameters']['Coefficient']
         self.fitted_parameters = coefs.tolist()
+        
+        # Save merged choice table to the class object for diagnostic use
+        self.mergedchoicetable = data
             
     
     def _get_chosen_ids(self, ids, positions):


### PR DESCRIPTION
This is a small PR that adds code to save the estimation data table to the `LargeMultinomialLogitStep` class object for diagnostic use, after a model is estimated. For example, this lets users check which alternatives were sampled for each chooser.

The table is saved to the `mergedchoicetable` property, with type `choicemodels.tools.MergedChoiceTable`. To get the data, you can use:

````py
df = m.mergedchoicetable.to_frame()
````

#### Versioning

- version numbers are unchanged