### PR TITLE
Simplify versioning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='urbansim_templates',
-    version='0.1.dev10',
+    version='0.1.dev11',
     description='UrbanSim extension for managing model steps',
     author='UrbanSim Inc.',
     author_email='info@urbansim.com',

--- a/urbansim_templates/__init__.py
+++ b/urbansim_templates/__init__.py
@@ -1,1 +1,1 @@
-version = __version__ = '0.1.dev10'
+version = __version__ = '0.1.dev11'

--- a/urbansim_templates/modelmanager.py
+++ b/urbansim_templates/modelmanager.py
@@ -11,7 +11,7 @@ from .models import BinaryLogitStep
 from .models import LargeMultinomialLogitStep
 from .models import SmallMultinomialLogitStep
 
-from __init__ import __version__
+from .__init__ import __version__
 from .utils import version_greater_or_equal
 
 
@@ -166,7 +166,7 @@ def get_step(name):
     RegressionStep or other
     
     """
-    return globals()[_STEPS[name]['type']].from_dict(_STEPS[name])    
+    return globals()[_STEPS[name]['template']].from_dict(_STEPS[name])    
 
 
 def remove_step(name):

--- a/urbansim_templates/modelmanager.py
+++ b/urbansim_templates/modelmanager.py
@@ -11,10 +11,9 @@ from .models import BinaryLogitStep
 from .models import LargeMultinomialLogitStep
 from .models import SmallMultinomialLogitStep
 
+from __init__ import __version__
 from .utils import version_greater_or_equal
 
-
-MODELMANAGER_VERSION = '0.1.dev10'
 
 _STEPS = {}  # master dictionary of steps in memory
 _DISK_STORE = None  # path to saved steps on disk
@@ -50,6 +49,7 @@ def initialize(path='configs'):
     
     if len(files) == 0:
         print("No yaml files found in path '{}'".format(path))
+        return
         
     steps = []
     for f in files:
@@ -145,7 +145,7 @@ def save_step(d):
     print("Saving '{}.yaml': {}".format(d['name'], 
             os.path.join(os.getcwd(), _DISK_STORE)))
     
-    headers = {'modelmanager_version': MODELMANAGER_VERSION}
+    headers = {'modelmanager_version': __version__}
 
     content = OrderedDict(headers)
     content.update({'saved_object': d})

--- a/urbansim_templates/models/binary_logit.py
+++ b/urbansim_templates/models/binary_logit.py
@@ -8,8 +8,10 @@ from statsmodels.api import Logit
 
 import orca
 
-from .shared import TemplateStep
+from ..__init__ import __version__
 from .. import modelmanager as mm
+
+from .shared import TemplateStep
 
 
 TEMPLATE_VERSION = '0.1dev1'

--- a/urbansim_templates/models/binary_logit.py
+++ b/urbansim_templates/models/binary_logit.py
@@ -8,13 +8,9 @@ from statsmodels.api import Logit
 
 import orca
 
-from ..__init__ import __version__
+from .shared import TemplateStep
 from .. import modelmanager as mm
 
-from .shared import TemplateStep
-
-
-TEMPLATE_VERSION = '0.1dev1'
 
 class BinaryLogitStep(TemplateStep):
     """
@@ -101,8 +97,6 @@ class BinaryLogitStep(TemplateStep):
         TemplateStep.__init__(self, tables=tables, model_expression=model_expression, 
                 filters=filters, out_tables=out_tables, out_column=out_column, 
                 out_transform=None, out_filters=out_filters, name=name, tags=tags)
-        
-        self.version = TEMPLATE_VERSION
         
         # Custom parameters not in parent class
         self.out_value_true = out_value_true

--- a/urbansim_templates/models/large_multinomial_logit.py
+++ b/urbansim_templates/models/large_multinomial_logit.py
@@ -14,8 +14,6 @@ from .shared import TemplateStep
 from .. import modelmanager as mm
 
 
-TEMPLATE_VERSION = '0.1.dev3'
-
 class LargeMultinomialLogitStep(TemplateStep):
     """
     A class for building multinomial logit model steps where the number of alternatives is
@@ -135,8 +133,6 @@ class LargeMultinomialLogitStep(TemplateStep):
                 filters=None, out_tables=None, out_column=out_column, out_transform=None, 
                 out_filters=None, name=name, tags=tags)
 
-        self.version = TEMPLATE_VERSION
-        
         # Custom parameters not in parent class
         self.choosers = choosers
         self.alternatives = alternatives
@@ -196,7 +192,8 @@ class LargeMultinomialLogitStep(TemplateStep):
         
         """
         d = {
-            'type': self.type,
+            'template': self.template,
+            'template_version': self.template_version,
             'name': self.name,
             'tags': self.tags,
             'choosers': self.choosers,

--- a/urbansim_templates/models/regression.py
+++ b/urbansim_templates/models/regression.py
@@ -12,8 +12,6 @@ from .shared import TemplateStep
 from .. import modelmanager as mm
 
 
-TEMPLATE_VERSION = '0.1dev1'
-
 class OLSRegressionStep(TemplateStep):
     """
     A class for building OLS (ordinary least squares) regression model steps. This extends 
@@ -96,8 +94,6 @@ class OLSRegressionStep(TemplateStep):
                 filters=filters, out_tables=out_tables, out_column=out_column, 
                 out_transform=out_transform, out_filters=out_filters, name=name, 
                 tags=tags)
-        
-        self.version = TEMPLATE_VERSION
         
         # Placeholders for model fit data, filled in by fit() or from_dict()
         self.summary_table = None 

--- a/urbansim_templates/models/shared.py
+++ b/urbansim_templates/models/shared.py
@@ -9,6 +9,7 @@ import orca
 from urbansim.models import util
 
 from .. import modelmanager as mm
+from ..__init__ import __version__
 
 
 class TemplateStep(object):
@@ -53,7 +54,8 @@ class TemplateStep(object):
         self.name = name
         self.tags = tags
         
-        self.type = type(self).__name__  # class name
+        self.template = type(self).__name__  # class name
+        self.template_version = __version__
                 
 
     @classmethod
@@ -92,8 +94,8 @@ class TemplateStep(object):
         
         """
         d = {
-            'type': self.type,
-            'version': self.version,
+            'template': self.type,
+            'template_version': self.template_version,
             'name': self.name,
             'tags': self.tags,
             'tables': self.tables,
@@ -321,8 +323,8 @@ class TemplateStep(object):
         str
         
         """
-        if (self.name is None) or (self.type in self.name):
-            return self.type + '-' + dt.now().strftime('%Y%m%d-%H%M%S')
+        if (self.name is None) or (self.template in self.name):
+            return self.template + '-' + dt.now().strftime('%Y%m%d-%H%M%S')
         else:
             return self.name
 

--- a/urbansim_templates/models/shared.py
+++ b/urbansim_templates/models/shared.py
@@ -94,7 +94,7 @@ class TemplateStep(object):
         
         """
         d = {
-            'template': self.type,
+            'template': self.template,
             'template_version': self.template_version,
             'name': self.name,
             'tags': self.tags,

--- a/urbansim_templates/models/small_multinomial_logit.py
+++ b/urbansim_templates/models/small_multinomial_logit.py
@@ -14,8 +14,6 @@ from .shared import TemplateStep
 from .. import modelmanager as mm
 
 
-TEMPLATE_VERSION = '0.1dev1'
-
 class SmallMultinomialLogitStep(TemplateStep):
     """
     A class for building multinomial logit model steps where the number of alternatives is
@@ -109,8 +107,6 @@ class SmallMultinomialLogitStep(TemplateStep):
         TemplateStep.__init__(self, tables=tables, model_expression=model_expression, 
                 filters=filters, out_tables=out_tables, out_column=out_column, 
                 out_transform=None, out_filters=out_filters, name=name, tags=tags)
-        
-        self.version = TEMPLATE_VERSION
         
         # Custom parameters not in parent class
         self.model_labels = model_labels

--- a/urbansim_templates/tests/test_binary_logit.py
+++ b/urbansim_templates/tests/test_binary_logit.py
@@ -1,0 +1,36 @@
+import orca
+import numpy as np
+import pandas as pd
+import pytest
+
+from urbansim_templates import modelmanager as mm
+from urbansim_templates.models import BinaryLogitStep
+
+
+d1 = {'a': np.random.random(100),
+      'b': np.random.randint(2, size=100)}
+
+obs = pd.DataFrame(d1)
+orca.add_table('obs', obs)
+
+
+def test_binary_logit():
+    """
+    For now this just tests that the code runs.
+    
+    """
+    mm.initialize()
+
+    m = BinaryLogitStep()
+    m.tables = 'obs'
+    m.model_expression = 'b ~ a'
+    
+    m.fit()
+    
+    m.name = 'binary-test'
+    m.register()
+    
+    mm.initialize()
+    m = mm.get_step('binary-test')
+    
+    mm.remove_step('binary-test')

--- a/urbansim_templates/tests/test_regression.py
+++ b/urbansim_templates/tests/test_regression.py
@@ -1,0 +1,36 @@
+import orca
+import numpy as np
+import pandas as pd
+import pytest
+
+from urbansim_templates import modelmanager as mm
+from urbansim_templates.models import OLSRegressionStep
+
+
+d1 = {'a': np.random.random(100),
+      'b': np.random.random(100)}
+
+obs = pd.DataFrame(d1)
+orca.add_table('obs', obs)
+
+
+def test_ols():
+    """
+    For now this just tests that the code runs.
+    
+    """
+    mm.initialize()
+
+    m = OLSRegressionStep()
+    m.tables = 'obs'
+    m.model_expression = 'a ~ b'
+    
+    m.fit()
+    
+    m.name = 'ols-test'
+    m.register()
+    
+    mm.initialize()
+    m = mm.get_step('ols-test')
+    
+    mm.remove_step('ols-test')

--- a/urbansim_templates/tests/test_small_multinomial_logit.py
+++ b/urbansim_templates/tests/test_small_multinomial_logit.py
@@ -1,0 +1,40 @@
+import orca
+import numpy as np
+import pandas as pd
+import pytest
+from collections import OrderedDict
+
+from urbansim_templates import modelmanager as mm
+from urbansim_templates.models import SmallMultinomialLogitStep
+
+
+d1 = {'a': np.random.random(100),
+      'b': np.random.random(100),
+      'choice': np.random.randint(3, size=100)}
+
+obs = pd.DataFrame(d1)
+orca.add_table('obs', obs)
+
+
+def test_small_mnl():
+    """
+    For now this just tests that the code runs.
+    
+    """
+    mm.initialize()
+
+    m = SmallMultinomialLogitStep()
+    m.tables = 'obs'
+    m.choice_column = 'choice'
+    m.model_expression = OrderedDict([
+            ('intercept', [1,2]), ('a', [0,2]), ('b', [0,2])])
+    
+    m.fit()
+    
+    m.name = 'small-mnl-test'
+    m.register()
+    
+    mm.initialize()
+    m = mm.get_step('small-mnl-test')
+    
+    mm.remove_step('small-mnl-test')


### PR DESCRIPTION
This PR addresses issue #35.

It removes separate tracking of a `MODELMANAGER_VERSION` and a `TEMPLATE_VERSION`, substituting the current version number of the `urbansim_templates` library for both.

### Changes to template spec

- the `type` parameter of a saved model step is renamed to `template` for clarity: this is generated automatically and is the template's class name
- the `version` parameter of a saved model step is renamed to `template_version` for clarity

This should not cause any backward compatibility issues.

### Other changes

- adds simple unit tests for each of the model steps, checking that models can be estimated, saved, and reloaded without errors

### Versioning

- updates the library version to `0.1.dev11`