### PR TITLE
ModelManager architecture updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,14 @@ Open an issue, or contact Sam (maurer@urbansim.com).
 UrbanSim Templates treats model steps as _objects you can interact with_, rather than just functions with inputs and outputs. This enables some nice workflows, such as registration of model steps without needing to add them to a `models.py` file:
 
 ```py
-from urbansim_templates import modelmanager as mm
+from urbansim_templates import modelmanager
 from urbansim_templates.models import OLSRegressionStep
 
-mm.initialize()
+modelmanager.initialize()
 
 model = OLSRegressionStep(<parameters>)
 model.fit()
-model.register()
+modelmanager.register(model)
 
 # The model step is now registered with Orca and saved to disk. ModelManager tracks and
 # loads all previously saved steps, just as if they were listed in models.py.
@@ -49,7 +49,7 @@ orca.run(['name'])
 # If needed, the previously saved steps can be re-loaded into class instances that can be 
 # examined, copied, and edited.
 
-model2 = mm.get_model('name')
+model2 = modelmanager.get_model('name')
 ```
 
 Prior to ModelManager, the equivalent workflow would be to (1) estimate a model, (2) generate a config file for it, (3) write a function in `models.py` to register it with Orca, and (4) edit it by modifying the config file or creating a replacement.
@@ -61,19 +61,20 @@ ModelManager works directly with the current versions of [UrbanSim](https://gith
 
 - Let's keep the master branch of this library clean and runnable. To make fixes or add features, create a new branch, and open a pull request when you're ready to merge code into master. Have someone else review it before merging, if possible. There's a writeup of our general Git workflow [over here](https://github.com/ual/urbansim_parcel_bayarea/wiki/Git-workflows-and-tips).
 
-- Each substantive PR should increment the developer build number of the library, e.g. `0.1.dev0` -> `0.1.dev1`. The production release at the end of this sequence would be `0.1`, which would be followed by `0.2.dev0`. The library version number is saved in any yaml files a user creates, for troubleshooting and managing format changes.
+- Each substantive PR should increment the developer build number of the library, e.g. `0.1.dev0` -> `0.1.dev1`. The production release at the end of this sequence would be `0.1`, which would be followed by `0.2.dev0`. 
 
-   The version number needs to be updated in both `/setup.py` and `/urbansim_templates/__init__.py`. See further discussion in [issue #35](https://github.com/UDST/urbansim_templates/issues/35).
+   This versioning style is sometimes called "major.minor.micro with development releases" ([PEP 440](https://www.python.org/dev/peps/pep-0440/)). The version number is included in saved yaml files, for troubleshooting and managing format changes.
+
+   Note that the version number needs to be updated in both `/setup.py` and `/urbansim_templates/__init__.py`. See further discussion in [issue #35](https://github.com/UDST/urbansim_templates/issues/35).
 
 - Each PR writeup should carefully document the changes it includes -- especially any changes to the API or file storage format -- so that we can put together good release notes. This codebase will soon have many users.
 
 - A template is a Python class that conforms to the following spec:
 
-   1. can save itself to a dict  
+   1. can save itself to a dict using a method named `to_dict()`  
    2. can rebuild itself from a dict using a method named `from_dict()`  
    3. can execute a configured version of itself using a method named `run()`  
-   4. can register itself with `modelmanager` using a method named `register()`
-   5. accepts "name" and "tags" parameters
+   4. accepts parameters `name` (str) and `tags` (list of str)
 
 - ModelManager (`/urbansim_templates/modelmanager.py`) handles saving and reloading of configured template instances, aka model steps. It also registers them as Orca objects. 
 
@@ -83,7 +84,7 @@ ModelManager works directly with the current versions of [UrbanSim](https://gith
 
 - Data tables should be input as named Orca objects. Other inputs that are hard to store as strings (like callables) should probably be input as Orca objects as well; we're still working on a solution for this.
 
-- All template parameters should be accepted either as constructor parameters or object properties, if feasible:
+- All template inputs should be accepted either as constructor parameters or object properties, if feasible:
 
     ```py
     m1 = TemplateStep(foo='yes')
@@ -97,10 +98,10 @@ ModelManager works directly with the current versions of [UrbanSim](https://gith
 
 - Lightweight intermediate outputs like summary tables and fitted parameters should be saved in an object's dictionary representation if feasible.
 
-- It can be helpful to save more complex intermediate outputs to the class object so that users can access them (e.g. which observations were sampled, what the fitted probabilities are, etc) -- but we don't have a solution right now for saving these to disk.
+- Bigger intermediate outputs, like pickled copies of full fitted models, can be automatically stored to disk by providing an entry named `supplemental_objects` in a model's dictionary representation. This should contain a list of dicts, each of which has parameters `name` (str), `content` (obj), and `content_type` (str, e.g. 'pickle').
 
 - Shared template logic is in `shared.py` for now, but it's not very elegant. No need for templates to extend the `TemplateStep` class unless it's helpful.
 
-- Each new template class needs to be imported by name into `modelmanager.py`, for now. See discussion [here](https://github.com/UDST/urbansim_templates/blob/master/urbansim_templates/modelmanager.py#L105-L114).
+- Each new template class needs to be imported by name into `modelmanager.py`, for now. See discussion in [issue #42](https://github.com/UDST/urbansim_templates/issues/42).
 
 - We don't have design patterns yet for templates whose final output is to _generate_ DataFrames or Series, rather than modifying existing ones, but we're working on it.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Open an issue, or contact Sam (maurer@urbansim.com).
 
 ## Usage overview
 
-[Initialization-demo.ipynb](https://github.com/ual/urbansim_parcel_bayarea/blob/master/general-notebooks/Initialization-demo.ipynb)
+[Initialization-demo.ipynb](https://github.com/UDST/public-template-workspace/blob/master/notebooks-sam/2018-07-initialization-demo.ipynb)
 
 UrbanSim Templates treats model steps as _objects you can interact with_, rather than just functions with inputs and outputs. This enables some nice workflows, such as registration of model steps without needing to add them to a `models.py` file:
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='urbansim_templates',
-    version='0.1.dev11',
+    version='0.1.dev12',
     description='UrbanSim extension for managing model steps',
     author='UrbanSim Inc.',
     author_email='info@urbansim.com',

--- a/urbansim_templates/__init__.py
+++ b/urbansim_templates/__init__.py
@@ -1,1 +1,1 @@
-version = __version__ = '0.1.dev11'
+version = __version__ = '0.1.dev12'

--- a/urbansim_templates/modelmanager.py
+++ b/urbansim_templates/modelmanager.py
@@ -86,15 +86,25 @@ def list_steps():
     return l
 
 
+def register(step):
+    """
+    Register a model step with ModelManager and Orca. This includes saving it to disk so
+    it can be automatically loaded in the future.
+    
+    Registering a step will overwrite any previously loaded step with the same name.
+    
+    Parameters
+    ----------
+    step : ModelManager-compliant object with a `to_dict()` method.
+    
+    """
+    add_step(step.to_dict())
+
+
 def add_step(d, save_to_disk=True):
     """
-    Register a model step from a dictionary representation. This will override any 
-    previously registered step with the same name. The step will be registered with Orca 
-    and (if save_to_disk==True) written to persistent storage.
-    
-    Note: This function is intended for internal use. In a model building workflow, it's 
-    better to use an object's `register()` method to register it with ModelManager and 
-    save it to disk at the same time.
+    Internal function for adding a model step from a dictionary representation, and 
+    optionally saving it to disk.
     
     Parameters
     ----------

--- a/urbansim_templates/models/binary_logit.py
+++ b/urbansim_templates/models/binary_logit.py
@@ -9,7 +9,6 @@ from statsmodels.api import Logit
 import orca
 
 from .shared import TemplateStep
-from .. import modelmanager as mm
 
 
 class BinaryLogitStep(TemplateStep):
@@ -249,17 +248,3 @@ class BinaryLogitStep(TemplateStep):
         orca.get_table(tabname).update_col_from_series(colname, df[colname], cast=True)
         
         
-    def register(self):
-        """
-        Register the model step with Orca and the ModelManager. This includes saving it
-        to disk so it can be automatically loaded in the future. 
-        
-        Registering a step will rewrite any previously saved step with the same name. 
-        (If a custom name has not been provided, one is generated each time the `fit()` 
-        method runs.)
-                
-        """
-        d = self.to_dict()
-        mm.add_step(d)
-
-     

--- a/urbansim_templates/models/large_multinomial_logit.py
+++ b/urbansim_templates/models/large_multinomial_logit.py
@@ -11,7 +11,6 @@ from choicemodels import MultinomialLogit
 from choicemodels.tools import MergedChoiceTable
 
 from .shared import TemplateStep
-from .. import modelmanager as mm
 
 
 class LargeMultinomialLogitStep(TemplateStep):
@@ -435,17 +434,3 @@ class LargeMultinomialLogitStep(TemplateStep):
         # Print a message about limited usage
         print("Warning: choices are unconstrained; additional functionality in progress")
     
-
-    def register(self):
-        """
-        Register the model step with Orca and the ModelManager. This includes saving it
-        to disk so it can be automatically loaded in the future. 
-        
-        Registering a step will rewrite any previously saved step with the same name. 
-        (If a custom name has not been provided, one is generated each time the `fit()` 
-        method runs.)
-                
-        """
-        d = self.to_dict()
-        mm.add_step(d)
-

--- a/urbansim_templates/models/regression.py
+++ b/urbansim_templates/models/regression.py
@@ -9,7 +9,6 @@ from urbansim.models import RegressionModel
 from urbansim.utils import yamlio
 
 from .shared import TemplateStep
-from .. import modelmanager as mm
 
 
 class OLSRegressionStep(TemplateStep):
@@ -203,17 +202,3 @@ class OLSRegressionStep(TemplateStep):
         orca.get_table(tabname).update_col_from_series(colname, values, cast=True)
         
 
-    def register(self):
-        """
-        Register the model step with Orca and the ModelManager. This includes saving it
-        to disk so it can be automatically loaded in the future. 
-        
-        Registering a step will rewrite any previously saved step with the same name. 
-        (If a custom name has not been provided, one is generated each time the `fit()` 
-        method runs.)
-                
-        """
-        d = self.to_dict()
-        mm.add_step(d)
-            
-        

--- a/urbansim_templates/models/shared.py
+++ b/urbansim_templates/models/shared.py
@@ -8,7 +8,6 @@ from datetime import datetime as dt
 import orca
 from urbansim.models import util
 
-from .. import modelmanager as mm
 from ..__init__ import __version__
 
 

--- a/urbansim_templates/models/small_multinomial_logit.py
+++ b/urbansim_templates/models/small_multinomial_logit.py
@@ -158,7 +158,7 @@ class SmallMultinomialLogitStep(TemplateStep):
         
         if 'supplemental_objects' in d:
             for item in filter(None, d['supplemental_objects']):
-                if item['name'] is 'model-object':
+                if (item['name'] == 'model-object'):
                     obj.model = item['content']
         
         return obj

--- a/urbansim_templates/models/small_multinomial_logit.py
+++ b/urbansim_templates/models/small_multinomial_logit.py
@@ -11,7 +11,6 @@ from choicemodels import MultinomialLogit
 import orca
 
 from .shared import TemplateStep
-from .. import modelmanager as mm
 
 
 class SmallMultinomialLogitStep(TemplateStep):
@@ -205,6 +204,7 @@ class SmallMultinomialLogitStep(TemplateStep):
         })
         
         # Store a pickled version of the PyLogit fitted model
+        # TO DO - a method called to_dict() should not be writing to the filesystem
         if self.model is not None:
             self.model.to_pickle(os.path.join(mm.get_config_dir(), self.name+'.pkl'))
         
@@ -384,18 +384,4 @@ class SmallMultinomialLogitStep(TemplateStep):
 
         tabname = self._get_out_table()
         orca.get_table(tabname).update_col_from_series(colname, df._choices, cast=True)
-
-
-    def register(self):
-        """
-        Register the model step with Orca and the ModelManager. This includes saving it
-        to disk so it can be automatically loaded in the future. 
-        
-        Registering a step will rewrite any previously saved step with the same name. 
-        (If a custom name has not been provided, one is generated each time the `fit()` 
-        method runs.)
-                
-        """
-        d = self.to_dict()
-        mm.add_step(d)
 

--- a/urbansim_templates/models/small_multinomial_logit.py
+++ b/urbansim_templates/models/small_multinomial_logit.py
@@ -203,13 +203,29 @@ class SmallMultinomialLogitStep(TemplateStep):
             'summary_table': self.summary_table
         })
         
-        # Store a pickled version of the PyLogit fitted model
-        # TO DO - a method called to_dict() should not be writing to the filesystem
-        if self.model is not None:
-            self.model.to_pickle(os.path.join(mm.get_config_dir(), self.name+'.pkl'))
-        
         return d
     
+    
+    def get_extra_payloads(self):
+        """
+        Returns additional payloads beyond the dictionary representation of the object,
+        for storage by ModelManager or other purposes. 
+        
+        Each item is returned as a tuple whose contents are an object, the payload type,
+        and an indication of whether storing the item is required or optional.
+        
+        Returns
+        -------
+        list of tuples with format (object, str, bool)
+        
+        """
+        payloads = []
+        
+        if self.model is not None:
+            payloads.append(self.model, 'pickle', True)  # PyLogit fitted model
+        
+        return payloads
+        
     
     def _get_alts(self):
         """

--- a/urbansim_templates/tests/README.md
+++ b/urbansim_templates/tests/README.md
@@ -1,1 +1,1 @@
-Run tests from this folder using `pytest test_file.py`.
+Run tests from this folder using `pytest *.py -s`.

--- a/urbansim_templates/tests/test_binary_logit.py
+++ b/urbansim_templates/tests/test_binary_logit.py
@@ -7,14 +7,16 @@ from urbansim_templates import modelmanager
 from urbansim_templates.models import BinaryLogitStep
 
 
-d1 = {'a': np.random.random(100),
-      'b': np.random.randint(2, size=100)}
+@pytest.fixture
+def orca_session():
+    d1 = {'a': np.random.random(100),
+          'b': np.random.randint(2, size=100)}
 
-obs = pd.DataFrame(d1)
-orca.add_table('obs', obs)
+    obs = pd.DataFrame(d1)
+    orca.add_table('obs', obs)
 
 
-def test_binary_logit():
+def test_binary_logit(orca_session):
     """
     For now this just tests that the code runs.
     

--- a/urbansim_templates/tests/test_binary_logit.py
+++ b/urbansim_templates/tests/test_binary_logit.py
@@ -3,7 +3,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from urbansim_templates import modelmanager as mm
+from urbansim_templates import modelmanager
 from urbansim_templates.models import BinaryLogitStep
 
 
@@ -19,7 +19,7 @@ def test_binary_logit():
     For now this just tests that the code runs.
     
     """
-    mm.initialize()
+    modelmanager.initialize()
 
     m = BinaryLogitStep()
     m.tables = 'obs'
@@ -28,9 +28,9 @@ def test_binary_logit():
     m.fit()
     
     m.name = 'binary-test'
-    m.register()
+    modelmanager.register(m)
     
-    mm.initialize()
-    m = mm.get_step('binary-test')
+    modelmanager.initialize()
+    m = modelmanager.get_step('binary-test')
     
-    mm.remove_step('binary-test')
+    modelmanager.remove_step('binary-test')

--- a/urbansim_templates/tests/test_large_multinomial_logit.py
+++ b/urbansim_templates/tests/test_large_multinomial_logit.py
@@ -3,7 +3,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from urbansim_templates import modelmanager as mm
+from urbansim_templates import modelmanager
 from urbansim_templates.models import LargeMultinomialLogitStep
 
 
@@ -22,7 +22,7 @@ orca.add_table('alts', alts)
 
 
 def test_observation_sampling():
-    mm.initialize()
+    modelmanager.initialize()
 
     m = LargeMultinomialLogitStep()
     m.choosers = 'obs'
@@ -38,10 +38,10 @@ def test_observation_sampling():
     assert(len(m.mergedchoicetable.to_frame()) == 95)  # 100 after fixing alt sampling
     
     m.name = 'mnl-test'
-    m.register()
+    modelmanager.register(m)
     
-    mm.initialize()
-    m = mm.get_step('mnl-test')
+    modelmanager.initialize()
+    m = modelmanager.get_step('mnl-test')
     assert(m.chooser_sample_size == 5)
     
-    mm.remove_step('mnl-test')
+    modelmanager.remove_step('mnl-test')

--- a/urbansim_templates/tests/test_large_multinomial_logit.py
+++ b/urbansim_templates/tests/test_large_multinomial_logit.py
@@ -7,21 +7,23 @@ from urbansim_templates import modelmanager
 from urbansim_templates.models import LargeMultinomialLogitStep
 
 
-d1 = {'oid': np.arange(10), 
-      'obsval': np.random.random(10),
-      'choice': np.random.choice(np.arange(20), size=10)}
+@pytest.fixture
+def orca_session():
+    d1 = {'oid': np.arange(10), 
+          'obsval': np.random.random(10),
+          'choice': np.random.choice(np.arange(20), size=10)}
 
-d2 = {'aid': np.arange(20), 
-      'altval': np.random.random(20)}
+    d2 = {'aid': np.arange(20), 
+          'altval': np.random.random(20)}
 
-obs = pd.DataFrame(d1).set_index('oid')
-orca.add_table('obs', obs)
+    obs = pd.DataFrame(d1).set_index('oid')
+    orca.add_table('obs', obs)
 
-alts = pd.DataFrame(d2).set_index('aid')
-orca.add_table('alts', alts)
+    alts = pd.DataFrame(d2).set_index('aid')
+    orca.add_table('alts', alts)
 
 
-def test_observation_sampling():
+def test_observation_sampling(orca_session):
     modelmanager.initialize()
 
     m = LargeMultinomialLogitStep()

--- a/urbansim_templates/tests/test_regression.py
+++ b/urbansim_templates/tests/test_regression.py
@@ -7,14 +7,16 @@ from urbansim_templates import modelmanager
 from urbansim_templates.models import OLSRegressionStep
 
 
-d1 = {'a': np.random.random(100),
-      'b': np.random.random(100)}
+@pytest.fixture
+def orca_session():
+    d1 = {'a': np.random.random(100),
+          'b': np.random.random(100)}
 
-obs = pd.DataFrame(d1)
-orca.add_table('obs', obs)
+    obs = pd.DataFrame(d1)
+    orca.add_table('obs', obs)
 
 
-def test_ols():
+def test_ols(orca_session):
     """
     For now this just tests that the code runs.
     

--- a/urbansim_templates/tests/test_regression.py
+++ b/urbansim_templates/tests/test_regression.py
@@ -3,7 +3,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from urbansim_templates import modelmanager as mm
+from urbansim_templates import modelmanager
 from urbansim_templates.models import OLSRegressionStep
 
 
@@ -19,7 +19,7 @@ def test_ols():
     For now this just tests that the code runs.
     
     """
-    mm.initialize()
+    modelmanager.initialize()
 
     m = OLSRegressionStep()
     m.tables = 'obs'
@@ -28,9 +28,9 @@ def test_ols():
     m.fit()
     
     m.name = 'ols-test'
-    m.register()
+    modelmanager.register(m)
     
-    mm.initialize()
-    m = mm.get_step('ols-test')
+    modelmanager.initialize()
+    m = modelmanager.get_step('ols-test')
     
-    mm.remove_step('ols-test')
+    modelmanager.remove_step('ols-test')

--- a/urbansim_templates/tests/test_small_multinomial_logit.py
+++ b/urbansim_templates/tests/test_small_multinomial_logit.py
@@ -4,7 +4,7 @@ import pandas as pd
 import pytest
 from collections import OrderedDict
 
-from urbansim_templates import modelmanager as mm
+from urbansim_templates import modelmanager
 from urbansim_templates.models import SmallMultinomialLogitStep
 
 
@@ -21,7 +21,7 @@ def test_small_mnl():
     For now this just tests that the code runs.
     
     """
-    mm.initialize()
+    modelmanager.initialize()
 
     m = SmallMultinomialLogitStep()
     m.tables = 'obs'
@@ -32,9 +32,9 @@ def test_small_mnl():
     m.fit()
     
     m.name = 'small-mnl-test'
-    m.register()
+    modelmanager.register(m)
     
-    mm.initialize()
-    m = mm.get_step('small-mnl-test')
+    modelmanager.initialize()
+    m = modelmanager.get_step('small-mnl-test')
     
-    mm.remove_step('small-mnl-test')
+    modelmanager.remove_step('small-mnl-test')

--- a/urbansim_templates/tests/test_small_multinomial_logit.py
+++ b/urbansim_templates/tests/test_small_multinomial_logit.py
@@ -8,15 +8,17 @@ from urbansim_templates import modelmanager
 from urbansim_templates.models import SmallMultinomialLogitStep
 
 
-d1 = {'a': np.random.random(100),
-      'b': np.random.random(100),
-      'choice': np.random.randint(3, size=100)}
+@pytest.fixture
+def orca_session():
+    d1 = {'a': np.random.random(100),
+          'b': np.random.random(100),
+          'choice': np.random.randint(3, size=100)}
 
-obs = pd.DataFrame(d1)
-orca.add_table('obs', obs)
+    obs = pd.DataFrame(d1)
+    orca.add_table('obs', obs)
 
 
-def test_small_mnl():
+def test_small_mnl(orca_session):
     """
     For now this just tests that the code runs.
     


### PR DESCRIPTION
This PR updates the ModelManager architecture, mainly to:

1. move the `register()` operation from the templates to `modelmanager`
2. remove potential circular imports
3. add support for supplemental objects like pickled model results

These changes were interrelated, so i ended up implementing them together.

### Removing circular imports

The `register()` method was the only place where templates accessed `modelmanager` directly, so removing it allows us to avoid potential circular references. This resolves issue #40.

```py
m = <configured template object>

m.register()  # old usage, disabled by this PR
modelmanager.register(m)  # new usage
```

(This operation passes a configured template object to ModelManager, which registers it with the task orchestrator and saves it to disk for future reuse.)

### Support for supplemental objects

"Supplemental objects" is what i'm calling model components like pickled Scikit-learn data that are not feasible to store directly as text in the yaml file. See discussion in issue #37.

Previously, the `SmallMultinomialLogitStep` had implemented a version of this. I standardized the functionality and moved it into `modelmanager` so we can use it in other templates.

To take advantage of this, a template needs to provide a parameter named `supplemental_objects` in its dictionary representation. This should contain a list of dicts, each of which has parameters `name`, `content`, and `content_type`. 

ModelManager is set up to support particular content types (currently only 'pickle'), saving these alongside the yaml files and reloading them automatically.

- example of saving: [small_multinomial_logit.py#L202-L210](https://github.com/UDST/urbansim_templates/blob/f7e0afd54e7ffa5a27d6a3ff5f7057ff5bc03d30/urbansim_templates/models/small_multinomial_logit.py#L202-L210)
- example of reloading: [small_multinomial_logit.py#L159-L162](https://github.com/UDST/urbansim_templates/blob/f7e0afd54e7ffa5a27d6a3ff5f7057ff5bc03d30/urbansim_templates/models/small_multinomial_logit.py#L159-L162)
- backend implementation: [modelmanager.py](https://github.com/UDST/urbansim_templates/blob/f7e0afd54e7ffa5a27d6a3ff5f7057ff5bc03d30/urbansim_templates/modelmanager.py), e.g. [L174-L223](https://github.com/UDST/urbansim_templates/blob/f7e0afd54e7ffa5a27d6a3ff5f7057ff5bc03d30/urbansim_templates/modelmanager.py#L174-L223) for saving

There are some ancillary changes to facilitate this, mainly having ModelManager store full model objects in memory rather than dictionaries. None of the changes should affect other templates or the public-facing API.

### Other changes

- continues building out unit tests

### Versioning

- updates the library version to `0.1.dev12`