### PR TITLE
Adding template decorators

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ ModelManager works directly with the current versions of [UrbanSim](https://gith
    2. can rebuild itself from a dict using a method named `from_dict()`  
    3. can execute a configured version of itself using a method named `run()`  
    4. accepts parameters `name` (str) and `tags` (list of str)
+   5. uses the `@modelmanager.template` decorator
 
 - ModelManager (`/urbansim_templates/modelmanager.py`) handles saving and reloading of configured template instances, aka model steps. It also registers them as Orca objects. 
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='urbansim_templates',
-    version='0.1.dev12',
+    version='0.1.dev13',
     description='UrbanSim extension for managing model steps',
     author='UrbanSim Inc.',
     author_email='info@urbansim.com',

--- a/urbansim_templates/__init__.py
+++ b/urbansim_templates/__init__.py
@@ -1,1 +1,1 @@
-version = __version__ = '0.1.dev12'
+version = __version__ = '0.1.dev13'

--- a/urbansim_templates/modelmanager.py
+++ b/urbansim_templates/modelmanager.py
@@ -8,18 +8,27 @@ from collections import OrderedDict
 import orca
 from urbansim.utils import yamlio
 
-from .models import OLSRegressionStep
-from .models import BinaryLogitStep
-from .models import LargeMultinomialLogitStep
-from .models import SmallMultinomialLogitStep
-
 from .__init__ import __version__
 from .utils import version_greater_or_equal
 
 
-_steps = {}  # master dictionary of steps in memory
+_templates = {}  # global registry of template classes
+_steps = {}  # global registry of model steps in memory
 _disk_store = None  # path to saved steps on disk
 
+
+def template(cls):
+    """
+    This is a decorator for ModelManager-compliant template classes. Place
+    `@modelmanager.template` on the line before a class defintion.
+    
+    This makes the class available to ModelManager (e.g. for reading saved steps from 
+    disk) whenever it's imported.
+    
+    """
+    _templates[cls.__name__] = cls
+    return cls
+    
 
 def initialize(path='configs'):
     """
@@ -93,7 +102,7 @@ def build_step(d):
             content = load_supplemental_object(d['name'], **item)
             d['supplemental_objects'][i]['content'] = content
     
-    return globals()[d['template']].from_dict(d)
+    return _templates[d['template']].from_dict(d)
     
 
 def load_supplemental_object(step_name, name, content_type, required=True):

--- a/urbansim_templates/models/binary_logit.py
+++ b/urbansim_templates/models/binary_logit.py
@@ -8,9 +8,11 @@ from statsmodels.api import Logit
 
 import orca
 
+from .. import modelmanager
 from .shared import TemplateStep
 
 
+@modelmanager.template
 class BinaryLogitStep(TemplateStep):
     """
     A class for building binary logit model steps. This extends TemplateStep, where some

--- a/urbansim_templates/models/large_multinomial_logit.py
+++ b/urbansim_templates/models/large_multinomial_logit.py
@@ -10,9 +10,11 @@ from choicemodels import mnl
 from choicemodels import MultinomialLogit
 from choicemodels.tools import MergedChoiceTable
 
+from .. import modelmanager
 from .shared import TemplateStep
 
 
+@modelmanager.template
 class LargeMultinomialLogitStep(TemplateStep):
     """
     A class for building multinomial logit model steps where the number of alternatives is

--- a/urbansim_templates/models/regression.py
+++ b/urbansim_templates/models/regression.py
@@ -8,9 +8,11 @@ import orca
 from urbansim.models import RegressionModel
 from urbansim.utils import yamlio
 
+from .. import modelmanager
 from .shared import TemplateStep
 
 
+@modelmanager.template
 class OLSRegressionStep(TemplateStep):
     """
     A class for building OLS (ordinary least squares) regression model steps. This extends 

--- a/urbansim_templates/models/small_multinomial_logit.py
+++ b/urbansim_templates/models/small_multinomial_logit.py
@@ -10,9 +10,11 @@ import pandas as pd
 from choicemodels import MultinomialLogit
 import orca
 
+from .. import modelmanager
 from .shared import TemplateStep
 
 
+@modelmanager.template
 class SmallMultinomialLogitStep(TemplateStep):
     """
     A class for building multinomial logit model steps where the number of alternatives is


### PR DESCRIPTION
This PR implements a `@modelmanager.template` decorator. This is the approach we decided on in issue #42 for registering templates with ModelManager.

### Usage

Add the decorator to a template class definition:

```py
import modelmanager

@modelmanager.template
class MyTemplate()
      ...
```

This makes the class available to the currently running instance of ModelManager whenever it's imported. ModelManager needs access to the classes in order to load saved steps from disk.

### Discussion

This uses the same approach as Orca registrations, which is nice. And it's a good solution for allowing users to make custom templates.

All the prior unit tests are passing.

### Versioning

- updates the library version to 0.1.dev13