### PR TITLE
Updating Large MNL template with better simulation functionality

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='urbansim_templates',
-    version='0.1.dev14',
+    version='0.1.dev15',
     description='UrbanSim extension for managing model steps',
     author='UrbanSim Inc.',
     author_email='info@urbansim.com',

--- a/urbansim_templates/__init__.py
+++ b/urbansim_templates/__init__.py
@@ -1,1 +1,1 @@
-version = __version__ = '0.1.dev14'
+version = __version__ = '0.1.dev15'

--- a/urbansim_templates/models/large_multinomial_logit.py
+++ b/urbansim_templates/models/large_multinomial_logit.py
@@ -461,7 +461,8 @@ class LargeMultinomialLogitStep(TemplateStep):
         mct = MergedChoiceTable(observations, alternatives,
                                 sample_size = self.alt_sample_size)
         
-        model = MultinomialLogitResults(self.model_expression, self.fitted_parameters)
+        model = MultinomialLogitResults(model_expression = self.model_expression, 
+                                        fitted_parameters = self.fitted_parameters)
         probs = model.probabilities(mct)
         choices = monte_carlo_choices(probs)
         
@@ -507,6 +508,6 @@ class LargeMultinomialLogitStep(TemplateStep):
         
         table.update_col_from_series(column, choices, cast=True)
         
-        # Print a message about limited usage
-        print("Warning: choices are unconstrained; additional functionality in progress")
+#         Print a message about limited usage
+#         print("Warning: choices are unconstrained; additional functionality in progress")
     

--- a/urbansim_templates/models/large_multinomial_logit.py
+++ b/urbansim_templates/models/large_multinomial_logit.py
@@ -103,6 +103,26 @@ class LargeMultinomialLogitStep(TemplateStep):
         Filters to apply to the alternatives data before simulation. If not provided, no 
         filters will be applied. Replaces the `predict_filters` argument in UrbanSim.
 
+    constrained_choices : bool, optional
+        "True" means alternatives have limited capacity. "False" (default) means that 
+        alternatives can accommodate an unlimited number of choosers. 
+    
+    alt_capacity : str, optional
+        Name of a column in the out_alternatives table that expresses the capacity of
+        alternatives. If not provided and constrained_choices is True, each alternative
+        is interpreted as accommodating a single chooser. 
+    
+    chooser_size : str, optional
+        Name of a column in the out_choosers table that expresses the size of choosers.
+        Choosers might have varying sizes if the alternative capacities are amounts 
+        rather than counts -- e.g. square footage. Chooser sizes must be in the same units
+        as alternative capacities. If not provided and constrained_choices is True, each
+        chooser has a size of 1.
+        
+    max_iter : int or None, optional
+        Maximum number of choice simulation iterations. If None (default), the algorithm
+        will iterate until all choosers are matched or no alternatives remain.
+    
     name : str, optional
         Name of the model step, passed to ModelManager. If none is provided, a name is
         generated each time the `fit()` method runs.
@@ -115,7 +135,8 @@ class LargeMultinomialLogitStep(TemplateStep):
             choice_column=None, chooser_filters=None, chooser_sample_size=None,
             alt_filters=None, alt_sample_size=None, out_choosers=None, 
             out_alternatives=None, out_column=None, out_chooser_filters=None, 
-            out_alt_filters=None, name=None, tags=[]):
+            out_alt_filters=None, constrained_choices=False, alt_capacity=None, 
+            chooser_size=None, max_iter=None, name=None, tags=[]):
         
         self._listeners = []
         
@@ -136,6 +157,10 @@ class LargeMultinomialLogitStep(TemplateStep):
         self.out_alternatives = out_alternatives
         self.out_chooser_filters = out_chooser_filters
         self.out_alt_filters = out_alt_filters
+        self.constrained_choices = constrained_choices
+        self.alt_capacity = alt_capacity
+        self.chooser_size = chooser_size
+        self.max_iter = max_iter
         
         # Placeholders for model fit data, filled in by fit() or from_dict()
         self.summary_table = None 
@@ -173,7 +198,10 @@ class LargeMultinomialLogitStep(TemplateStep):
             alt_filters=d['alt_filters'], alt_sample_size=d['alt_sample_size'], 
             out_choosers=d['out_choosers'], out_alternatives=d['out_alternatives'], 
             out_column=d['out_column'], out_chooser_filters=d['out_chooser_filters'], 
-            out_alt_filters=d['out_alt_filters'], name=d['name'], tags=d['tags'])
+            out_alt_filters=d['out_alt_filters'], 
+            constrained_choices=d['constrained_choices'],  alt_capacity=d['alt_capacity'],  
+            chooser_size=d['chooser_size'],  max_iter=d['max_iter'], name=d['name'], 
+            tags=d['tags'])
 
         # Load model fit data
         obj.summary_table = d['summary_table']
@@ -209,6 +237,10 @@ class LargeMultinomialLogitStep(TemplateStep):
             'out_column': self.out_column,
             'out_chooser_filters': self.out_chooser_filters,
             'out_alt_filters': self.out_alt_filters,
+            'constrained_choices': self.constrained_choices,
+            'alt_capacity': self.alt_capacity,
+            'chooser_size': self.chooser_size,
+            'max_iter': self.max_iter,
             'summary_table': self.summary_table,
             'fitted_parameters': self.fitted_parameters,
         }
@@ -320,6 +352,38 @@ class LargeMultinomialLogitStep(TemplateStep):
     def out_alt_filters(self, value):
         self.__out_alt_filters = value
         self.send_to_listeners('out_alt_filters', value)
+            
+    @property
+    def constrained_choices(self):
+        return self.__constrained_choices
+    @constrained_choices.setter
+    def constrained_choices(self, value):
+        self.__constrained_choices = value
+        self.send_to_listeners('constrained_choices', value)
+            
+    @property
+    def alt_capacity(self):
+        return self.__alt_capacity
+    @alt_capacity.setter
+    def alt_capacity(self, value):
+        self.__alt_capacity = value
+        self.send_to_listeners('alt_capacity', value)
+            
+    @property
+    def chooser_size(self):
+        return self.__chooser_size
+    @chooser_size.setter
+    def chooser_size(self, value):
+        self.__chooser_size = value
+        self.send_to_listeners('chooser_size', value)
+            
+    @property
+    def max_iter(self):
+        return self.__max_iter
+    @max_iter.setter
+    def max_iter(self, value):
+        self.__max_iter = value
+        self.send_to_listeners('max_iter', value)
             
             
 #     def _get_alt_sample_size(self):

--- a/urbansim_templates/models/small_multinomial_logit.py
+++ b/urbansim_templates/models/small_multinomial_logit.py
@@ -18,10 +18,10 @@ from .shared import TemplateStep
 class SmallMultinomialLogitStep(TemplateStep):
     """
     A class for building multinomial logit model steps where the number of alternatives is
-    "small". Estimation is handled by ChoiceModels and PyLogit. Simulation is handled by
-    PyLogit (probabilities) and within this class (simulation draws). 
+    "small". Estimation is handled by PyLogit via the ChoiceModels API. Simulation is 
+    handled by PyLogit (probabilities) and ChoiceModels (simulation draws). 
     
-    Multinomial Logit models can involve a range of different specification and estimation
+    Multinomial logit models can involve a range of different specification and estimation
     mechanics. For now these are separated into two templates. What's the difference?
     
     "Small" MNL:

--- a/urbansim_templates/tests/test_large_multinomial_logit.py
+++ b/urbansim_templates/tests/test_large_multinomial_logit.py
@@ -116,6 +116,25 @@ def test_simulation_single_occupancy(m):
     assert len(obs) == len(obs.choice.unique())
     
     
+def test_simulation_constrained(m):
+    """
+    Test simulation of choices with explicit capacities and sizes.
     
+    """
+    obs = orca.get_table('obs').to_frame()
+    obs.loc[:,'choice'] = -1
+    obs['size'] = np.random.choice([1,2], size=len(obs))
+    orca.add_table('obs', obs)
     
+    alts = orca.get_table('alts').to_frame()
+    alts['cap'] = np.random.choice([1,2,3], size=len(alts))
+    orca.add_table('alts', alts)
     
+    m.constrained_choices = True
+    m.alt_capacity = 'cap'
+    m.chooser_size = 'size'
+    m.run()
+    
+    obs = orca.get_table('obs').to_frame()
+    assert all(~obs.choice.isin([-1]))
+

--- a/urbansim_templates/tests/test_large_multinomial_logit.py
+++ b/urbansim_templates/tests/test_large_multinomial_logit.py
@@ -104,7 +104,16 @@ def test_simulation_unconstrained(m):
     assert obs.loc[:24, 'choice'].equals(m.choices)
     
     
+def test_simulation_single_occupancy(m):
+    """
+    Test simulation of single-occupancy choices.
     
+    """
+    m.constrained_choices = True
+    m.run()
+    
+    obs = orca.get_table('obs').to_frame()
+    assert len(obs) == len(obs.choice.unique())
     
     
     

--- a/urbansim_templates/tests/test_large_multinomial_logit.py
+++ b/urbansim_templates/tests/test_large_multinomial_logit.py
@@ -33,11 +33,11 @@ def test_observation_sampling(orca_session):
     m.model_expression = 'obsval + altval'
     
     m.fit()
-    assert(len(m.mergedchoicetable.to_frame()) == 190)  # 200 after fixing alt sampling
+    assert(len(m.mergedchoicetable.to_frame()) == 200)
     
     m.chooser_sample_size = 5
     m.fit()
-    assert(len(m.mergedchoicetable.to_frame()) == 95)  # 100 after fixing alt sampling
+    assert(len(m.mergedchoicetable.to_frame()) == 100)
     
     m.name = 'mnl-test'
     modelmanager.register(m)

--- a/urbansim_templates/tests/test_large_multinomial_logit.py
+++ b/urbansim_templates/tests/test_large_multinomial_logit.py
@@ -85,6 +85,37 @@ def m(data):
     return m
 
 
+def test_property_persistence(m):
+    """
+    Test persistence of properties across registration, saving, and reloading.
+    
+    """
+    m.fit()
+    m.name = 'my-model'
+    m.tags = ['tag1']
+    m.chooser_filters = 'filters1'
+    m.chooser_sample_size = 100
+    m.alt_filters = 'filter2'
+    m.out_choosers = 'choosers2'
+    m.out_alternatives = 'alts2'
+    m.out_column = 'choices'
+    m.out_chooser_filters = 'filters3'
+    m.out_alt_filters = 'filters4'
+    m.constrained_choices = True
+    m.alt_capacity = 'cap'
+    m.chooser_size = 'size'
+    m.max_iter = 17
+    
+    d1 = m.to_dict()
+    modelmanager.initialize()
+    modelmanager.register(m)
+    modelmanager.initialize()
+    d2 = modelmanager.get_step('my-model').to_dict()
+    
+    assert d1 == d2
+    modelmanager.remove_step('my-model')
+    
+
 def test_simulation_unconstrained(m):
     """
     Test simulation chooser filters with unconstrained choices.


### PR DESCRIPTION
This PR updates the `LargeMultinomialLogitStep` template with better simulation functionality. 

It requires ChoiceModels 0.2.dev4, aka [choicemodels PR #44](https://github.com/UDST/choicemodels/pull/44).

### Changes

- Adds some new template parameters for choice simulation:
   - `constrained_choices`: True/False
   - `alt_capacity`: column from the `out_alternatives` table
   - `chooser_size`: column from the `out_choosers` table
   - `max_iter`: maximum number of choice simulation iterations to allow, only relevant in unusual situations where it's difficult to match choosers to appropriate alternatives

- Updates the `run()` method to use new simulation utilities from ChoiceModels: `monte_carlo_choices()` for unconstrained simulation and `iterative_lottery_choices()` for constrained simulation. 

- Improves unit tests

### Usage

Use the `out_column` parameter to set a location for saving simulated choices. See docstrings for other related parameters.

Use the `out_chooser_filters` parameter to specify which agents to simulate choices for. Leaving this empty will simulate choices for all of the agents.

For unconstrained choices (alternatives can be chosen an unlimited number of times), set `constrained_choices = False`.

For constrained choices, set `constrained_choices = True`. The default behavior here is for each alternative to accommodate one chooser. For count-based capacities (each alternative accommodates N choosers), set an `alt_capacity` column. For amount-based capacities (alternatives have size N and choosers have size M), also set a `chooser_size` column. 

### Versioning

- updates the library version to 0.1.dev15