### PR TITLE
[0.1.dev20] Bugfix: Small MNL model_expression persistence

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ requirements = [item.strip() for item in requirements]
 
 setup(
     name='urbansim_templates',
-    version='0.1.dev19',
+    version='0.1.dev20',
     description='UrbanSim extension for managing model steps',
     author='UrbanSim Inc.',
     author_email='info@urbansim.com',

--- a/urbansim_templates/__init__.py
+++ b/urbansim_templates/__init__.py
@@ -1,1 +1,1 @@
-version = __version__ = '0.1.dev19'
+version = __version__ = '0.1.dev20'

--- a/urbansim_templates/models/small_multinomial_logit.py
+++ b/urbansim_templates/models/small_multinomial_logit.py
@@ -179,6 +179,7 @@ class SmallMultinomialLogitStep(TemplateStep):
         self.model_expression = None
         
         d = TemplateStep.to_dict(self)
+        self.model_expression = tmp_model_expression
         
         # Can't store OrderedDicts in YAML, so convert them
         if tmp_model_expression is not None:

--- a/urbansim_templates/tests/test_small_multinomial_logit.py
+++ b/urbansim_templates/tests/test_small_multinomial_logit.py
@@ -29,7 +29,7 @@ def test_template_validity():
 
 def test_small_mnl(orca_session):
     """
-    For now this just tests that the code runs.
+    Test that the code runs, and that the model_expression is always available.
     
     """
     modelmanager.initialize()
@@ -41,11 +41,14 @@ def test_small_mnl(orca_session):
             ('intercept', [1,2]), ('a', [0,2]), ('b', [0,2])])
     
     m.fit()
+    assert(m.model_expression is not None)
     
     m.name = 'small-mnl-test'
     modelmanager.register(m)
+    assert(m.model_expression is not None)
     
     modelmanager.initialize()
     m = modelmanager.get_step('small-mnl-test')
+    assert(m.model_expression is not None)
     
     modelmanager.remove_step('small-mnl-test')


### PR DESCRIPTION
This PR fixes a bug: when a Small MNL model was saved, the `model_expression` was inadvertently being deleted from the copy of the model step in memory. This is now fixed, with a unit test added that confirms it. Should resolve issue #71.