### PR TITLE
automatically add interaction term table indices to list of columns r…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ requirements = [item.strip() for item in requirements]
 
 setup(
     name='urbansim_templates',
-    version='0.1.dev22',
+    version='0.1.dev23',
     description='UrbanSim extension for managing model steps',
     author='UrbanSim Inc.',
     author_email='info@urbansim.com',

--- a/urbansim_templates/__init__.py
+++ b/urbansim_templates/__init__.py
@@ -1,1 +1,1 @@
-version = __version__ = '0.1.dev22'
+version = __version__ = '0.1.dev23'

--- a/urbansim_templates/models/large_multinomial_logit.py
+++ b/urbansim_templates/models/large_multinomial_logit.py
@@ -497,7 +497,10 @@ class LargeMultinomialLogitStep(TemplateStep):
         if interaction_terms is not None:
             obs_extra_cols = to_list(self.chooser_size) + list(interaction_terms.index.names)[0]
             alts_extra_cols = to_list(self.alt_capacity) + list(interaction_terms.index.names)[1]
-
+        else:
+            obs_extra_cols = self.chooser_size
+            alts_extra_cols = self.alt_capacity
+            
         observations = get_data(tables = self.out_choosers, 
                                 fallback_tables = self.choosers, 
                                 filters = self.out_chooser_filters,

--- a/urbansim_templates/models/large_multinomial_logit.py
+++ b/urbansim_templates/models/large_multinomial_logit.py
@@ -475,9 +475,9 @@ class LargeMultinomialLogitStep(TemplateStep):
             Additional column(s) of interaction terms whose values depend on the 
             combination of observation and alternative, to be merged onto the final data 
             table. If passed as a Series or DataFrame, it should include a two-level 
-            MultiIndex. The outermost level's name and values should match an index or
-            column from the observations table, and the second should match an index or
-            column from the alternatives table. 
+            MultiIndex. One level's name and values should match an index or column from 
+            the observations table, and the other should match an index or column from the 
+            alternatives table. 
         
         Returns
         -------
@@ -495,12 +495,12 @@ class LargeMultinomialLogitStep(TemplateStep):
                     "https://github.com/udst/choicemodels.")
 
         if interaction_terms is not None:
-            obs_extra_cols = to_list(self.chooser_size) + list(interaction_terms.index.names)[0]
-            alts_extra_cols = to_list(self.alt_capacity) + list(interaction_terms.index.names)[1]
+            obs_extra_cols = to_list(self.chooser_size) + list(interaction_terms.index.names)
+            alts_extra_cols = to_list(self.alt_capacity) + list(interaction_terms.index.names)
         else:
             obs_extra_cols = self.chooser_size
             alts_extra_cols = self.alt_capacity
-            
+
         observations = get_data(tables = self.out_choosers, 
                                 fallback_tables = self.choosers, 
                                 filters = self.out_chooser_filters,

--- a/urbansim_templates/models/large_multinomial_logit.py
+++ b/urbansim_templates/models/large_multinomial_logit.py
@@ -4,7 +4,7 @@ import orca
 # choicemodels imports are in the fit() and run() methods
 
 from .. import modelmanager
-from ..utils import get_data, version_greater_or_equal
+from ..utils import get_data, version_greater_or_equal, to_list
 from .shared import TemplateStep
 
 
@@ -475,9 +475,9 @@ class LargeMultinomialLogitStep(TemplateStep):
             Additional column(s) of interaction terms whose values depend on the 
             combination of observation and alternative, to be merged onto the final data 
             table. If passed as a Series or DataFrame, it should include a two-level 
-            MultiIndex. One level's name and values should match an index or column from 
-            the observations table, and the other should match an index or column from the 
-            alternatives table. 
+            MultiIndex. The outermost level's name and values should match an index or
+            column from the observations table, and the second should match an index or
+            column from the alternatives table. 
         
         Returns
         -------
@@ -494,17 +494,21 @@ class LargeMultinomialLogitStep(TemplateStep):
                     "choicemodels 0.2.dev4 or later. For installation instructions, see "
                     "https://github.com/udst/choicemodels.")
 
+        if interaction_terms is not None:
+            obs_extra_cols = to_list(self.chooser_size) + list(interaction_terms.index.names)[0]
+            alts_extra_cols = to_list(self.alt_capacity) + list(interaction_terms.index.names)[1]
+
         observations = get_data(tables = self.out_choosers, 
                                 fallback_tables = self.choosers, 
                                 filters = self.out_chooser_filters,
                                 model_expression = self.model_expression,
-                                extra_columns = self.chooser_size)
+                                extra_columns = obs_extra_cols)
         
         alternatives = get_data(tables = self.out_alternatives, 
                                 fallback_tables = self.alternatives, 
                                 filters = self.out_alt_filters,
                                 model_expression = self.model_expression,
-                                extra_columns = self.alt_capacity)
+                                extra_columns = alts_extra_cols)
         
         model = MultinomialLogitResults(model_expression = self.model_expression, 
                 fitted_parameters = self.fitted_parameters)


### PR DESCRIPTION
…equired to generate merged choice table object.

The only tricky thing about this PR is that it requires the indices of a multi-indexed table of interaction terms to have the indices ordered, with the index corresponding to the observations table as the outermost or first index, and the the index corresponding the the alternatives table is the second or innermost index. I have updated the docstrings accordingly in the `large_multinomial_logit.run()` method, and also in the choicemodels.tools.mergedchoicetable constructor in a PR [here](https://github.com/UDST/choicemodels/pull/55).