### PR TITLE
[0.1.dev25] Fixing bug with OLS simulation to new output column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # UrbanSim Templates change log
 
+### 0.1.dev25 (2019-01-15)
+
+- fixes an OLS simulation bug that raised an error when output column didn't exist yet
+
+- implements `out_transform` for OLS simulation
+
 ### 0.1.dev24 (2018-12-20)
 
 - fixes a string comparison bug that caused problems with binary logit output in Windows

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ requirements = [item.strip() for item in requirements]
 
 setup(
     name='urbansim_templates',
-    version='0.1.dev24',
+    version='0.1.dev25',
     description='UrbanSim extension for managing model steps',
     author='UrbanSim Inc.',
     author_email='info@urbansim.com',

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -45,3 +45,22 @@ def test_ols(orca_session):
     m = modelmanager.get_step('ols-test')
     
     modelmanager.remove_step('ols-test')
+
+
+def test_simulation(orca_session):
+    """
+    Test that predicted values are correctly written to Orca.
+    
+    """
+    modelmanager.initialize()
+    
+    m = OLSRegressionStep()
+    m.tables = 'obs'
+    m.model_expression = 'a ~ b'
+    m.fit()
+    
+    m.out_column = 'a_predicted'
+    m.run()
+    
+    assert orca.get_table('obs').to_frame()['a_predicted'].equals(m.predicted_values)
+

--- a/urbansim_templates/__init__.py
+++ b/urbansim_templates/__init__.py
@@ -1,1 +1,1 @@
-version = __version__ = '0.1.dev24'
+version = __version__ = '0.1.dev25'


### PR DESCRIPTION
This PR fixes a bug where OLS simulation raised an error when the output column didn't exist yet. This functionality should have been included in PR #79, but I missed it.

### Other changes

- implements optional `out_transform` for OLS simulation

### Versioning

- this is dev release 0.1.dev25