### PR TITLE
[0.1.1.dev0] Allow join keys as data filters in MNL simulation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ requirements = [item.strip() for item in requirements]
 
 setup(
     name='urbansim_templates',
-    version='0.1',
+    version='0.1.1.dev0',
     description='UrbanSim extension for managing model steps',
     author='UrbanSim Inc.',
     author_email='info@urbansim.com',

--- a/tests/test_large_multinomial_logit.py
+++ b/tests/test_large_multinomial_logit.py
@@ -259,3 +259,27 @@ def test_diagnostic_attributes(data):
     modelmanager.remove_step(name)
 
 
+def test_simulation_join_key_as_filter(m):
+    """
+    This tests that it's possible to use a join key as a both a data filter for one of 
+    the tables, and as a choice column for the model. 
+    
+    This came up because MergedChoiceTable doesn't allow the observations and 
+    alternatives to have any column names in common -- the rationale is to maintain data 
+    traceability by avoiding any of-the-fly renaming or dropped columns. 
+    
+    In the templates, in order to support things like using 'households.building_id' as a 
+    filter column and 'buildings.building_id' as a choice column, we apply the filters 
+    and then drop columns that are no longer needed before merging the tables. 
+    
+    """
+    obs = orca.get_table('obs')
+    obs['aid'] = obs.get_column('choice')
+    
+    m.out_choosers = 'obs'
+    m.out_chooser_filters = 'aid > 50'
+    m.out_alternatives = 'alts'
+    m.out_column = 'aid'
+    
+    m.run()
+

--- a/urbansim_templates/__init__.py
+++ b/urbansim_templates/__init__.py
@@ -1,1 +1,1 @@
-version = __version__ = '0.1'
+version = __version__ = '0.1.1.dev0'


### PR DESCRIPTION
This PR allows join keys to be used as data filters in MNL simulation.

### Discussion

Since ChoiceModels [0.2.dev7](https://github.com/UDST/choicemodels/pull/54), MergedChoiceTable has raised an error if there are overlapping column names in the choosers and alternatives tables -- the rationale is to maintain data traceability by avoiding any on-the-fly renaming or dropped columns.

So if there's already a join key linking the choosers and alternatives, it can't be included in a MergedChoiceTable because it won't be clear which table it came from. (MCT randomly matches choosers with hypothetical alternatives -- it doesn't join the tables using keys.)

Sometimes we might want to use a join key for data filtering prior to building the MCT, though, for example to select agents whose `household.building_id` indicates that they're currently unmatched. 

This PR updates the Large MNL template to support that: the filter is applied, and then the filter column is dropped before generating the MergedChoiceTable to avoid a name conflict.

### Versioning

This PR is 0.1.1.dev0