### PR TITLE
[0.2.dev1] Fixes Small MNL simulation crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # UrbanSim Templates change log
 
+### 0.2.dev1 (2019-02-27)
+
+- fixes a crash in small MNL simulation
+
 ### 0.2.dev0 (2019-02-19)
 
 - adds first data i/o template: `urbansim_templates.io.TableFromDisk()`

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -10,7 +10,7 @@ UrbanSim Templates provides building blocks for Orca-based simulation models. It
 
 The library contains templates for common types of model steps, plus a tool called ModelManager that runs as an extension to the `Orca <https://udst.github.io/orca>`__ task orchestrator. ModelManager can register template-based model steps with the orchestrator, save them to disk, and automatically reload them for future sessions.
 
-v0.2.dev0, released February 19, 2019
+v0.2.dev1, released February 27, 2019
 
 
 Contents

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ requirements = [item.strip() for item in requirements]
 
 setup(
     name='urbansim_templates',
-    version='0.2.dev0',
+    version='0.2.dev1',
     description='UrbanSim extension for managing model steps',
     author='UrbanSim Inc.',
     author_email='info@urbansim.com',

--- a/tests/test_small_multinomial_logit.py
+++ b/tests/test_small_multinomial_logit.py
@@ -11,12 +11,29 @@ from urbansim_templates.utils import validate_template
 
 @pytest.fixture
 def orca_session():
-    d1 = {'a': np.random.random(100),
-          'b': np.random.random(100),
+    d1 = {'id': np.arange(100),
+          'building_id': np.arange(100),
+          'a': np.random.random(100),
           'choice': np.random.randint(3, size=100)}
+    
+    d2 = {'building_id': np.arange(100),
+          'b': np.random.random(100)}
 
-    obs = pd.DataFrame(d1)
-    orca.add_table('obs', obs)
+    households = pd.DataFrame(d1).set_index('id')
+    orca.add_table('households', households)
+    
+    buildings = pd.DataFrame(d2).set_index('building_id')
+    orca.add_table('buildings', buildings)
+
+    orca.broadcast(cast='buildings', onto='households', 
+                   cast_index=True, onto_on='building_id')
+
+#     d1 = {'a': np.random.random(100),
+#           'b': np.random.random(100),
+#           'choice': np.random.randint(3, size=100)}
+# 
+#     obs = pd.DataFrame(d1)
+#     orca.add_table('obs', obs)    
 
 
 def test_template_validity():
@@ -35,7 +52,7 @@ def test_small_mnl(orca_session):
     modelmanager.initialize()
 
     m = SmallMultinomialLogitStep()
-    m.tables = 'obs'
+    m.tables = ['households', 'buildings']
     m.choice_column = 'choice'
     m.model_expression = OrderedDict([
             ('intercept', [1,2]), ('a', [0,2]), ('b', [0,2])])
@@ -50,6 +67,13 @@ def test_small_mnl(orca_session):
     assert(m.model_expression is not None)
     
     print(m.model_expression)
+    
+    # TEST SIMULATION
+    m.out_column = 'simulated_choice'
+    # orca.get_table('households')['simulated_choice'] = 0
+    
+    m.run()
+    print(orca.get_table('households').to_frame())
     
     modelmanager.initialize()
     m = modelmanager.get_step('small-mnl-test')

--- a/tests/test_small_multinomial_logit.py
+++ b/tests/test_small_multinomial_logit.py
@@ -28,13 +28,6 @@ def orca_session():
     orca.broadcast(cast='buildings', onto='households', 
                    cast_index=True, onto_on='building_id')
 
-#     d1 = {'a': np.random.random(100),
-#           'b': np.random.random(100),
-#           'choice': np.random.randint(3, size=100)}
-# 
-#     obs = pd.DataFrame(d1)
-#     orca.add_table('obs', obs)    
-
 
 def test_template_validity():
     """
@@ -70,7 +63,6 @@ def test_small_mnl(orca_session):
     
     # TEST SIMULATION
     m.out_column = 'simulated_choice'
-    # orca.get_table('households')['simulated_choice'] = 0
     
     m.run()
     print(orca.get_table('households').to_frame())

--- a/urbansim_templates/__init__.py
+++ b/urbansim_templates/__init__.py
@@ -1,1 +1,1 @@
-version = __version__ = '0.2.dev0'
+version = __version__ = '0.2.dev1'

--- a/urbansim_templates/models/shared.py
+++ b/urbansim_templates/models/shared.py
@@ -204,16 +204,6 @@ class TemplateStep(object):
         return df
 
 
-    def _get_filter_columns(self):
-        """
-        THIS METHOD DOES NOT WORK YET.   
-        
-        Return list of column names referenced in the filters.
-        
-        """
-        return
-    
-    
     def _get_out_column(self):
         """
         Return name of the column to save data to. This is 'out_column' if it exsits,

--- a/urbansim_templates/models/shared.py
+++ b/urbansim_templates/models/shared.py
@@ -168,16 +168,6 @@ class TemplateStep(object):
         if isinstance(self.model_expression, str):
             expr_cols = util.columns_in_formula(self.model_expression)
         
-        # This is for PyLogit model expressions
-        elif isinstance(self.model_expression, OrderedDict):
-            # TO DO - check that this works in Python 2.7
-            expr_cols = [t[0] for t in list(self.model_expression.items()) \
-                         if t[0] != 'intercept']
-            # TO DO - not very general, maybe we should just override the method
-            # TO DO - and this only applies to the fit condition
-            if self.choice_column is not None:
-                expr_cols += [self.choice_column]
-        
         if (task == 'fit'):
             tables = self.tables
             columns = expr_cols + util.columns_in_filters(self.filters)

--- a/urbansim_templates/models/small_multinomial_logit.py
+++ b/urbansim_templates/models/small_multinomial_logit.py
@@ -10,9 +10,9 @@ import pandas as pd
 from choicemodels import MultinomialLogit
 import orca
 
-from ..utils import update_column
-from .. import modelmanager
-from .shared import TemplateStep
+from urbansim_templates import modelmanager
+from urbansim_templates.models import TemplateStep
+from urbansim_templates.utils import get_data, update_column
 
 
 @modelmanager.template
@@ -87,8 +87,6 @@ class SmallMultinomialLogitStep(TemplateStep):
         in the primary output table, it will be created. If not provided, the 
         `choice_column` will be used. Replaces the `out_fname` argument in UrbanSim.
         
-        # TO DO - auto-generation not yet working; column must exist in the primary table
-
     out_filters : str or list of str, optional
         Filters to apply to the data before simulation. If not provided, no filters will
         be applied. Replaces the `predict_filters` argument in UrbanSim.
@@ -319,7 +317,8 @@ class SmallMultinomialLogitStep(TemplateStep):
         if (self.initial_coefs is None) or (len(self.initial_coefs) != pc):
             self.initial_coefs = np.zeros(pc).tolist()
 
-        model = MultinomialLogit(data=long_df, observation_id_col='_obs_id',
+        model = MultinomialLogit(data=long_df, 
+                                 observation_id_col='_obs_id',
                                  choice_col='_chosen',
                                  model_expression=self.model_expression,
                                  model_labels=self.model_labels,
@@ -352,7 +351,14 @@ class SmallMultinomialLogitStep(TemplateStep):
         model step.
         
         """
-        df = self._get_data('predict')
+        expr_cols = [t[0] for t in list(self.model_expression.items()) \
+                     if t[0] != 'intercept']
+        
+        df = get_data(tables = self.out_tables,
+                      fallback_tables = self.tables,
+                      filters = self.out_filters,
+                      extra_columns = expr_cols)
+
         long_df = self._to_long(df, 'predict')
         
         num_obs = len(df)

--- a/urbansim_templates/models/small_multinomial_logit.py
+++ b/urbansim_templates/models/small_multinomial_logit.py
@@ -310,7 +310,14 @@ class SmallMultinomialLogitStep(TemplateStep):
         with Orca or ModelManager until the `register()` method is run. 
         
         """
-        long_df = self._to_long(self._get_data())
+        expr_cols = [t[0] for t in list(self.model_expression.items()) \
+                     if t[0] != 'intercept']
+        
+        df = get_data(tables = self.tables,
+                      filters = self.filters,
+                      extra_columns = expr_cols + [self.choice_column])
+
+        long_df = self._to_long(df)
         
         # Set initial coefs to 0 if none provided
         pc = self._get_param_count()


### PR DESCRIPTION
This PR fixes a problem in the Small MNL template that was causing crashes in the simulation stage. This was identified by @xyzjayne. 

### Problem

Small MNL model steps were crashing in the simulation stage if the output column didn't exist yet, or in certain cases when multiple tables were being assembled.

### Causes

When data was being assembled for simulation, the older `TemplateStep._get_data()` method was requesting the `out_column` because we used to update it locally before updating Orca ([shared.py#L194](https://github.com/UDST/urbansim_templates/blob/5b8a3b37914e632370aee8c72c7d1e3afcd5f31f/urbansim_templates/models/shared.py#L194)). This caused errors when the column didn't exist yet.

It was also requesting the `choice_column` even when simulating, because of a coding mistake involving the special case of PyLogit model expressions ([shared.py#L179](https://github.com/UDST/urbansim_templates/blob/5b8a3b37914e632370aee8c72c7d1e3afcd5f31f/urbansim_templates/models/shared.py#L179)), which i think was contributing to some of the crashes.

### Solution

I updated the Small MNL template to use the new, cleaner `utils.get_data()` function for both estimation and simulation. 

### Testing

I replicated the crash in a unit test, and the changes resolve it. @xyzjayne reports that this branch fixes the crashes she was seeing as well. 

### Versioning

This PR increments the master branch to 0.2.dev1. 

This seems like a pretty important bug fix, so i'm also going to apply these changes to the most recent production version and release it as v0.1.2 on pip and conda. (It will be at least a few weeks before v0.2 is ready for release.)

### Before merging

- [x] update changelog and version in docs