### PR TITLE
Updates contribution guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,97 +1,99 @@
 # UrbanSim Templates change log
 
-### 0.2.dev0 (2019-02-19)
+
+## 0.2 (not yet released)
+
+#### 0.2.dev1 (2019-02-27)
+
+- fixes a crash in small MNL simulation
+
+#### 0.2.dev0 (2019-02-19)
 
 - adds first data i/o template: `urbansim_templates.io.TableFromDisk()`
 - adds support for `autorun` template property
 
-### 0.1.1 (2019-02-05)
 
-- production release
+## 0.1.2 (2019-02-28)
 
-### 0.1.1.dev1 (2019-01-30)
+- patch to incorporate the small MNL bug fix from 0.2.dev1
+
+
+## 0.1.1 (2019-02-05)
+
+#### 0.1.1.dev1 (2019-01-30)
 
 - adds support for passing multiple tables of interaction terms in large MNL
 - enables on-the-fly creation of output columns in small MNL
 
-### 0.1.1.dev0 (2019-01-20)
+#### 0.1.1.dev0 (2019-01-20)
 
 - allows join keys to be used as data filters in MNL simulation
 
-### 0.1 (2019-01-16)
 
-- first production release!
+## 0.1 (2019-01-16)
 
-### 0.1.dev25 (2019-01-15)
+#### 0.1.dev25 (2019-01-15)
 
 - fixes an OLS simulation bug that raised an error when the output column didn't exist yet
-
 - implements `out_transform` for OLS simulation
 
-### 0.1.dev24 (2018-12-20)
+#### 0.1.dev24 (2018-12-20)
 
 - fixes a string comparison bug that caused problems with binary logit output in Windows
-
 - adds `model` as an attribute of large MNL model steps, which provides a `choicemodels.MultinomialLogitResults` object and is available any time after a model step is fitted
-
 - enables on-the-fly creation of output columns in large MNL
-
 - fixes a large MNL simulation bug when there are no valid choosers or alternatives after evaluating the filters
-
 - moves unit tests out of the module directory
 
-### 0.1.dev23 (2018-12-13)
+#### 0.1.dev23 (2018-12-13)
 
 - fixes a bug with interaction terms passed into `LargeMultinomialLogitStep.run()`
 
-### 0.1.dev22 (2018-12-13)
+#### 0.1.dev22 (2018-12-13)
 
 - narrows the output of `utils.get_data()` to include only the columns requested (plus the index of the primary table) -- previously Orca had also provided some extra columns such as join keys
 
-### 0.1.dev21 (2018-12-11)
+#### 0.1.dev21 (2018-12-11)
 
 - adds a new function `utils.get_data()` to assemble data from Orca, automatically detecting columns included in model expressions and filters
 
 - implements `SegmentedLargeMultinomialLogit.run_all()`
 
-### 0.1.dev20 (2018-12-11)
+#### 0.1.dev20 (2018-12-11)
 
 - fixes a model expression persistence bug in the small MNL template
 
-### 0.1.dev19 (2018-12-06)
+#### 0.1.dev19 (2018-12-06)
 
 - fixes a bug to allow large MNL simulation with multiple chooser tables
 
-### 0.1.dev18 (2018-11-19)
+#### 0.1.dev18 (2018-11-19)
 
 - improves installation and testing
 
-### 0.1.dev17 (2018-11-15)
+#### 0.1.dev17 (2018-11-15)
 
 - adds an `interaction_terms` parameter that users can manually pass to `LargeMultinomialLogitStep.run()`, as a temporary solution until interaction terms are fully handled by the templates
-
 - also adds a `chooser_batch_size` parameter in the same place, to reduce memory pressure when there are large numbers of choosers
 
-### 0.1.dev16 (2018-11-06)
+#### 0.1.dev16 (2018-11-06)
 
 - adds a tool for testing template validity
 
-### 0.1.dev15 (2018-10-15)
+#### 0.1.dev15 (2018-10-15)
 
 - adds new `LargeMultinomialLogitStep` parameters related to choice simulation: `constrained_choices`, `alt_capacity`, `chooser_size`, and `max_iter`
-
 - updates `LargeMultinomialLogitStep.run()` to use improved simulation utilities from ChoiceModels 0.2.dev4
 
-### 0.1.dev14 (2018-09-25)
+#### 0.1.dev14 (2018-09-25)
 
 - adds a template for segmented large MNL models: `SegmentedLargeMultinomialLogitStep`, which can automatically generate a set of large MNL models based on segmentation rules
 
-### 0.1.dev13 (2018-09-24)
+#### 0.1.dev13 (2018-09-24)
 
 - adds a `@modelmanager.template` decorator that makes a class available to the currently running instance of ModelManager
 
-### 0.1.dev12 (2018-09-19)
+#### 0.1.dev12 (2018-09-19)
 
 - moves the `register()` operation to `modelmanager` (previously it was a method implemented by the individual templates)
-
 - adds general ModelManager support for supplemental objects like pickled model results

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,7 @@ You can contact Sam Maurer, the lead developer, at `maurer@urbansim.com`.
 
 - After merging, tag the release on Github and follow the normal distribution procedures
 
-- After the new release is tagged, you can delete the extra branches -- a branch is just a tag pointing to the latest commit in a chain, and the commits will still be there
+- After the new release is tagged, you can delete the extra branches -- a branch is just a pointer to the latest commit in a chain, and these commits will still be accessible via the tag
 
 
 ## Distributing a release on PyPI (for pip installation):

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,55 +1,94 @@
-Thanks for using UrbanSim Templates! This is an open source project that's part of the Urban Data Science Toolkit. Development and maintenance is a collaboration between UrbanSim Inc and U.C. Berkeley's Urban Analytics Lab. You can contact Sam Maurer, the lead developer, at `maurer@urbansim.com`.
+Thanks for using UrbanSim Templates! 
 
-### If you encounter an error or find a bug:
+This is an open source project that's part of the Urban Data Science Toolkit. Development and maintenance is a collaboration between UrbanSim Inc and U.C. Berkeley's Urban Analytics Lab. 
 
-- Take a look at the [open issues](https://github.com/UDST/urbansim_templates/issues) and [closed issues](https://github.com/UDST/urbansim_templates/issues?q=is%3Aissue+is%3Aclosed) to see if there's already a discussion of the problem
+You can contact Sam Maurer, the lead developer, at `maurer@urbansim.com`.
 
-- Open a new issue describing the problem: circumstances, error messages, operating system you are using, version of python, and version of any libraries that may be relevant
 
-### If you have a feature proposal:
+## If you have a problem:
 
-- Take a look at the [open issues](https://github.com/UDST/urbansim_templates/issues) and [closed issues](https://github.com/UDST/urbansim_templates/issues?q=is%3Aissue+is%3Aclosed) to see if there's already a discussion of the topic
+- Take a look at the [open issues](https://github.com/UDST/urbansim_templates/issues) and [closed issues](https://github.com/UDST/urbansim_templates/issues?q=is%3Aissue+is%3Aclosed) to see if there's already a related discussion
+
+- Open a new issue describing the problem -- if possible, include any error messages, the operating system and version of python you're using, and versions of any libraries that may be relevant
+
+
+## Feature proposals:
+
+- Take a look at the [open issues](https://github.com/UDST/urbansim_templates/issues) and [closed issues](https://github.com/UDST/urbansim_templates/issues?q=is%3Aissue+is%3Aclosed) to see if there's already a related discussion
 
 - Post your proposal as a new issue, so we can discuss it (some proposals may not be a good fit for the project)
 
-### Adding a feature or fixing a bug:
 
-- Create a new branch of UDST/urbansim_templates, or fork the repository to your own account
+## Contributing code:
 
-- Make your changes, adhering to the existing styles for coding, commenting, and especially the documentation strings at the beginning of functions
+- Create a new branch of `UDST/urbansim_templates`, or fork the repository to your own account
 
-- Add [tests](https://github.com/UDST/urbansim_templates/tree/master/tests) if possible
+- Make your changes, following the existing styles for code and inline documentation
 
-- When you're ready to begin code review, open a pull request to the UDST/urbansim_templates master branch
+- Add [tests](https://github.com/UDST/urbansim_templates/tree/master/tests) if possible!
 
-- The pull request writeup should be clear and thorough, to facilitate code review, documentation, and release notes (see [example here](https://github.com/UDST/choicemodels/pull/43)). First, briefly summarize the changes, referencing any associated issue threads. Then describe the changes in more detail: implementation, usage, performance, and anything else that's relevant
+- Open a pull request to the `UDST/urbansim_templates` master branch, including a writeup of your changes -- take a look at some of the closed PR's for examples
 
-- Make note in the pull request writeup of any API changes (class/method/function names, parameters, and behavior), particularly changes that could affect users' existing code
+- Current maintainers will review the code, suggest changes, and hopefully merge it!
 
-- Each substantial pull request should increment the development version number, e.g. from 0.2.dev7 to 0.2.dev8
 
-- If incrementing the version number: (1) update `setup.py`, (2) update `urbansim_templates/__init__.py`, (3) add a section to `CHANGELOG.md`, and (4) add the version number to the beginning of the pull request name
+## Updating the version number:
 
-### Preparing a production release:
+- Each pull request that changes substantive code should increment the development version number, e.g. from `0.2.dev7` to `0.2.dev8`, so that users know exactly which version they're running
 
-- Create a branch for release prep
+- It works best to do this just before merging (in case other PR's are merged first, and so you know the release date for the changelog and documentation)
 
-- Make sure all the tests are passing
+- There are three places where the version number needs to be changed: 
+  - `setup.py`
+  - `urbansim_templates/__init__.py`
+  - `docs/source/index.rst`
 
-- Update the version number (e.g. from 0.2.dev8 to 0.2) in `setup.py` and `urbansim_templates/__init__.py`
+- Please also add a section to `CHANGELOG.md` describing the changes!
 
-- Update `CHANGELOG.md`, collapsing development release sections into a single, reorganized list
 
-- Check if updates are needed to `README.md` and to the documentation source files
+## Updating the documentation: 
 
-- Rebuild the documentation webpages (DETAILS TK)
+- See instructions in `docs/README.md`
 
-- Open a pull request to the master branch
 
-- Merge the pull request
+## Preparing a production release:
+
+- Make a new branch for release prep
+
+- Update the version number and `CHANGELOG.md`
+
+- Make sure all the tests are passing, and check if updates are needed to `README.md` or to the documentation
+
+- Open a pull request to the master branch and merge it
 
 - Tag the release on Github
 
-- Update the Python Package Index (DETAILS TK)
 
-- Update the UDST Conda channel (DETAILS TK)
+## Distributing a release on PyPI (for pip installation):
+
+- Register an account at https://pypi.org, ask one of the current maintainers to add you to the project, and `pip install twine`
+
+- Run `python setup.py sdist bdist_wheel --universal`
+
+- This should create a `dist` directory containing two package files -- delete any old ones before the next step
+
+- Run `twine upload dist/*` -- this will prompt you for your pypi.org credentials
+
+- Check https://pypi.org/project/urbansim-templates/ for the new version
+
+
+## Distributing a release on Conda Forge (for conda installation):
+
+- Make a fork of the [conda-forge/urbansim_templates-feedstock](https://github.com/conda-forge/urbansim_templates-feedstock) repository -- there may already be a fork in udst
+
+- Edit `recipe/meta.yaml`: 
+  - update the version number
+  - paste a new hash matching the tar.gz file that was uploaded to pypi (it's available on the pypi.org project page)
+
+- Check that the run requirements still match `requirements.txt`
+
+- Open a pull request to the `conda-forge/urbansim_templates-feedstock` master branch
+
+- Automated tests will run, and after they pass one of the current project maintainers will be able to merge the PR -- you can add your Github user name to the maintainers list in `meta.yaml` for the next update
+
+- Check https://anaconda.org/conda-forge/urbansim-templates for the new version (may take a few minutes for it to appear)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,9 +64,26 @@ You can contact Sam Maurer, the lead developer, at `maurer@urbansim.com`.
 - Tag the release on Github
 
 
+## Patching an earlier release:
+
+- We're not maintaining separate code branches for dev/ production/ major releases, but you can easily recreate them from tags if you need to patch an earlier release
+
+- In Github, create a new branch from the tag for the version you'd like to patch, calling it something like `v1-production`
+
+- Create a second branch from that one, called something like `v1-patch`
+
+- Make your changes in the `v1-patch` branch, and open a PR to `v1-production` to finalize it
+
+- After merging, tag the release on Github and follow the normal distribution procedures
+
+- After the new release is tagged, you can delete the extra branches -- a branch is just a tag pointing to the latest commit in a chain, and the commits will still be there
+
+
 ## Distributing a release on PyPI (for pip installation):
 
 - Register an account at https://pypi.org, ask one of the current maintainers to add you to the project, and `pip install twine`
+
+- Check out the copy of the code you'd like to release
 
 - Run `python setup.py sdist bdist_wheel --universal`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,9 +59,9 @@ You can contact Sam Maurer, the lead developer, at `maurer@urbansim.com`.
 
 - Make sure all the tests are passing, and check if updates are needed to `README.md` or to the documentation
 
-- Open a pull request to the master branch and merge it
+- Open a pull request to the master branch to finalize it
 
-- Tag the release on Github
+- After merging, tag the release on Github and follow the distribution procedures below
 
 
 ## Patching an earlier release:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ conda install urbansim --channel udst
 
 ### Documentation
 
-See the online documentation for much more: [http://docs.udst.org/projects/urbansim-templates](https://docs.udst.org/projects/urbansim-templates/en/latest)
+See the online documentation for much more: https://urbansim-templates.readthedocs.io
 
 Some additional documentation is available within the repo in `CHANGELOG.md`, `CONTRIBUTING.md`, `/docs/README.md`, and `/tests/README.md`.
 


### PR DESCRIPTION
This PR improves the documentation:

- updates `CONTRIBUTING.md` to include additional clarity and detail borrowed from ChoiceModels
- adds a section on patching earlier releases
- changes the format of `CHANGELOG.md` to group dev releases within the associated production release

### Versioning

unchanged

### To do before merging

- [x] test the instructions for patching earlier releases