### PR TITLE
[0.2.dev6] Introducing settings objects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,8 @@ matrix:
     - python: '3.7'  # temp solution until python 3.7 is more cleanly supported
       dist: xenial
       sudo: true
-  allow_failures:
-    - python: '3.7'  # dependencies are blocking installation
-  fast_finish: true
 
 install:
-  - pip install git+git://github.com/udst/choicemodels.git
   - pip install .
   - pip install -r requirements-extras.txt
   - pip install -r requirements-dev.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,15 @@
 
 ## 0.2 (not yet released)
 
+#### 0.2.dev6 (2019-04-04)
+
+- introduces classes for storing common settings: `shared.CoreTemplateSettings`, `shared.OutputColumnSettings`
+- adds new shared functions: `shared.register_column()`, `utils.cols_in_expression()`
+- modifies `ColumnFromExpression` template to divide its parameters into three groups
+
 #### 0.2.dev5 (2019-03-29)
 
-- adds new template: `urbansim_templates.data.ColumnFromExpression`
+- adds new template: `data.ColumnFromExpression`
 
 #### 0.2.dev4 (2019-03-26)
 
@@ -20,8 +26,8 @@
 
 #### 0.2.dev2 (2019-03-04)
 
-- adds template for saving data: `urbansim_templates.data.SaveTable()`
-- renames `TableFromDisk()` to `urbansim_templates.data.LoadTable()`
+- adds template for saving data: `data.SaveTable()`
+- renames `io.TableFromDisk()` to `data.LoadTable()`
 
 #### 0.2.dev1 (2019-02-27)
 
@@ -29,7 +35,7 @@
 
 #### 0.2.dev0 (2019-02-19)
 
-- adds first data i/o template: `urbansim_templates.io.TableFromDisk()`
+- adds first data i/o template: `io.TableFromDisk()`
 - adds support for `autorun` template property
 
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -37,6 +37,7 @@ import sphinx_rtd_theme
 # ones.
 extensions = [
     'sphinx.ext.autodoc',
+    'sphinx.ext.autosummary',
     'sphinx.ext.napoleon',
     'sphinx.ext.viewcode']
 

--- a/docs/source/data-templates.rst
+++ b/docs/source/data-templates.rst
@@ -1,13 +1,10 @@
-Data template APIs
-==================
+Data management templates
+=========================
 
 Usage
 -----
 
-Data templates help you load tables into `Orca <https://udst.github.io/orca>`__ or save tables or subsets of tables to disk. 
-
-Example
-~~~~~~~
+Data templates help you load tables into `Orca <https://udst.github.io/orca>`__, create columns of derived data, or save tables or subsets of tables to disk. 
 
 .. code-block:: python
     
@@ -75,22 +72,42 @@ From Orca's perspective, tables set up using the :mod:`~urbansim_templates.data.
 Unlike the templates, Orca relies on user-specified "`broadcast <http://udst.github.io/orca/core.html#merge-api>`__" relationships to perform automatic merging of tables. :mod:`~urbansim_templates.data.LoadTable` does not register any broadcasts, because they're not needed if tables follow the schema rules above. So if you use these tables in non-template model steps, you may need to add broadcasts separately.
 
 
-LoadTable()
------------
+Data loading API
+----------------
+
+.. currentmodule:: urbansim_templates.data
+
+.. autosummary::
+    LoadTable
 
 .. autoclass:: urbansim_templates.data.LoadTable
    :members:
 
 
-SaveTable()
------------
+Column creation API
+-------------------
+
+.. currentmodule:: urbansim_templates.data
+
+.. autosummary::
+    ColumnFromExpression
+    ExpressionSettings
+
+.. autoclass:: urbansim_templates.data.ColumnFromExpression
+   :members:
+
+.. autoclass:: urbansim_templates.data.ExpressionSettings
+   :members:
+
+Data output API
+---------------
+
+.. currentmodule:: urbansim_templates.data
+
+.. autosummary::
+    SaveTable
 
 .. autoclass:: urbansim_templates.data.SaveTable
    :members:
 
 
-ColumnFromExpression()
-----------------------
-
-.. autoclass:: urbansim_templates.data.ColumnFromExpression
-   :members:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -10,7 +10,7 @@ UrbanSim Templates provides building blocks for Orca-based simulation models. It
 
 The library contains templates for common types of model steps, plus a tool called ModelManager that runs as an extension to the `Orca <https://udst.github.io/orca>`__ task orchestrator. ModelManager can register template-based model steps with the orchestrator, save them to disk, and automatically reload them for future sessions.
 
-v0.2.dev5, released March 29, 2019
+v0.2.dev6, released April 4, 2019
 
 
 Contents

--- a/docs/source/utilities.rst
+++ b/docs/source/utilities.rst
@@ -1,32 +1,87 @@
-Utilities API
-=============
+Shared utilities
+================
 
 The utilities are mainly helper functions for templates. 
 
 
-Template validation
--------------------
+General template tools API
+--------------------------
 
-.. automodule:: urbansim_templates.utils
-   :members: validate_template
+.. currentmodule:: urbansim_templates.shared
+
+.. autosummary::
+    CoreTemplateSettings
+
+.. automodule:: urbansim_templates.shared
+   :members: CoreTemplateSettings
 
 
-Table schemas and merging
--------------------------
+Column output tools API
+-----------------------
+
+.. currentmodule:: urbansim_templates.shared
+
+.. autosummary::
+    OutputColumnSettings
+    register_column
+
+.. automodule:: urbansim_templates.shared
+   :members: OutputColumnSettings, register_column
+
+
+Table schemas and merging API
+-----------------------------
+
+.. currentmodule:: urbansim_templates.utils
+
+.. autosummary::
+    validate_table
+    validate_all_tables
+    merge_tables
 
 .. automodule:: urbansim_templates.utils
    :members: validate_table, validate_all_tables, merge_tables
 
 
-Other helper functions
-----------------------
+Other helper functions API
+--------------------------
+
+.. currentmodule:: urbansim_templates.utils
+
+.. autosummary::
+    all_cols
+    cols_in_expression
+    get_data
+    get_df
+    trim_cols
+    to_list
+    update_column
+    update_name
 
 .. automodule:: urbansim_templates.utils
-   :members: all_cols, get_data, get_df, trim_cols, update_column, to_list, update_column, update_name
+   :members: all_cols, cols_in_expression, get_data, get_df, trim_cols, to_list, update_column, update_name
 
 
-Version management
-------------------
+Spec validation API
+-------------------
+
+.. currentmodule:: urbansim_templates.utils
+
+.. autosummary::
+    validate_template
+
+.. automodule:: urbansim_templates.utils
+   :members: validate_template
+
+
+Version management API
+----------------------
+
+.. currentmodule:: urbansim_templates.utils
+
+.. autosummary::
+    parse_version
+    version_greater_or_equal
 
 .. automodule:: urbansim_templates.utils
    :members: parse_version, version_greater_or_equal

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ requirements = [item.strip() for item in requirements]
 
 setup(
     name='urbansim_templates',
-    version='0.2.dev5',
+    version='0.2.dev6',
     description='UrbanSim extension for managing model steps',
     author='UrbanSim Inc.',
     author_email='info@urbansim.com',

--- a/tests/test_column_expression.py
+++ b/tests/test_column_expression.py
@@ -26,12 +26,12 @@ def orca_session():
     orca.add_table('obs', df)
 
 
-def test_template_validity():
-    """
-    Check template conforms to basic spec.
-    
-    """
-    assert validate_template(ColumnFromExpression)
+# def test_template_validity():
+#     """
+#     Check template conforms to basic spec.
+#     
+#     """
+#     assert validate_template(ColumnFromExpression)
 
 
 def test_missing_colname(orca_session):
@@ -163,7 +163,7 @@ def test_modelmanager_registration(orca_session):
     c.expression = 'a + b'
     
     modelmanager.register(c)
-    modelmanager.remove_step(c.name)
+    modelmanager.remove_step(c.meta.name)
     assert('c' in orca.get_table('obs').columns)
 
 
@@ -179,7 +179,7 @@ def test_expression_with_standalone_columns(orca_session):
     c.expression = 'a + b'
     
     modelmanager.register(c)
-    modelmanager.remove_step(c.name)
+    modelmanager.remove_step(c.meta.name)
 
     d = ColumnFromExpression()
     d.column_name = 'd'

--- a/tests/test_column_expression.py
+++ b/tests/test_column_expression.py
@@ -5,8 +5,24 @@ import pytest
 import orca
 
 from urbansim_templates import modelmanager
-from urbansim_templates.data import ColumnFromExpression
+from urbansim_templates.data import ColumnFromExpression, ExpressionSettings
 from urbansim_templates.utils import validate_template
+
+
+def test_expression_settings_persistence():
+    """
+    Confirm ExpressionSettings properties persist through to_dict() and from_dict().
+    
+    """
+    obj = ExpressionSettings()
+    obj.table = 'table'
+    obj.expression = 'expression'
+
+    d = obj.to_dict()
+    print(d)
+    
+    obj2 = ExpressionSettings.from_dict(d)
+    assert(obj2.to_dict() == d)
 
 
 @pytest.fixture

--- a/tests/test_column_expression.py
+++ b/tests/test_column_expression.py
@@ -40,8 +40,8 @@ def test_missing_colname(orca_session):
     
     """
     c = ColumnFromExpression()
-    c.table = 'tab'
-    c.expression = 'a'
+    c.data.table = 'tab'
+    c.data.expression = 'a'
     
     try:
         c.run()
@@ -58,8 +58,8 @@ def test_missing_table(orca_session):
     
     """
     c = ColumnFromExpression()
+    c.data.expression = 'a'
     c.output.column_name = 'col'
-    c.expression = 'a'
     
     try:
         c.run()
@@ -76,8 +76,8 @@ def test_missing_expression(orca_session):
     
     """
     c = ColumnFromExpression()
+    c.data.table = 'tab'
     c.output.column_name = 'col'
-    c.table = 'tab'
     
     try:
         c.run()
@@ -94,9 +94,9 @@ def test_expression(orca_session):
     
     """
     c = ColumnFromExpression()
+    c.data.table = 'obs'
+    c.data.expression = 'a * 5 + sqrt(b)'
     c.output.column_name = 'c'
-    c.table = 'obs'
-    c.expression = 'a * 5 + sqrt(b)'
     
     c.run()
     
@@ -114,9 +114,9 @@ def test_data_type(orca_session):
     orca.add_table('tab', pd.DataFrame({'a': [0.1, 1.33, 2.4]}))
     
     c = ColumnFromExpression()
+    c.data.table = 'tab'
+    c.data.expression = 'a'
     c.output.column_name = 'b'
-    c.table = 'tab'
-    c.expression = 'a'
     c.run()
     
     v1 = orca.get_table('tab').get_column('b').values
@@ -137,9 +137,9 @@ def test_missing_values(orca_session):
     orca.add_table('tab', pd.DataFrame({'a': [0.1, np.nan, 2.4]}))
     
     c = ColumnFromExpression()
+    c.data.table = 'tab'
+    c.data.expression = 'a'
     c.output.column_name = 'b'
-    c.table = 'tab'
-    c.expression = 'a'
     c.run()
     
     v1 = orca.get_table('tab').get_column('b').values
@@ -158,9 +158,9 @@ def test_modelmanager_registration(orca_session):
     
     """
     c = ColumnFromExpression()
+    c.data.table = 'obs'
+    c.data.expression = 'a + b'
     c.output.column_name = 'c'
-    c.table = 'obs'
-    c.expression = 'a + b'
     
     modelmanager.register(c)
     modelmanager.remove_step(c.meta.name)
@@ -174,17 +174,17 @@ def test_expression_with_standalone_columns(orca_session):
     
     """
     c = ColumnFromExpression()
+    c.data.table = 'obs'
+    c.data.expression = 'a + b'
     c.output.column_name = 'c'
-    c.table = 'obs'
-    c.expression = 'a + b'
     
     modelmanager.register(c)
     modelmanager.remove_step(c.meta.name)
 
     d = ColumnFromExpression()
+    d.data.table = 'obs'
+    d.data.expression = 'a + c'
     d.output.column_name = 'd'
-    d.table = 'obs'
-    d.expression = 'a + c'
     
     d.run()
     assert('d' in orca.get_table('obs').columns)

--- a/tests/test_column_expression.py
+++ b/tests/test_column_expression.py
@@ -58,7 +58,7 @@ def test_missing_table(orca_session):
     
     """
     c = ColumnFromExpression()
-    c.column_name = 'col'
+    c.output.column_name = 'col'
     c.expression = 'a'
     
     try:
@@ -76,7 +76,7 @@ def test_missing_expression(orca_session):
     
     """
     c = ColumnFromExpression()
-    c.column_name = 'col'
+    c.output.column_name = 'col'
     c.table = 'tab'
     
     try:
@@ -94,7 +94,7 @@ def test_expression(orca_session):
     
     """
     c = ColumnFromExpression()
-    c.column_name = 'c'
+    c.output.column_name = 'c'
     c.table = 'obs'
     c.expression = 'a * 5 + sqrt(b)'
     
@@ -114,7 +114,7 @@ def test_data_type(orca_session):
     orca.add_table('tab', pd.DataFrame({'a': [0.1, 1.33, 2.4]}))
     
     c = ColumnFromExpression()
-    c.column_name = 'b'
+    c.output.column_name = 'b'
     c.table = 'tab'
     c.expression = 'a'
     c.run()
@@ -122,7 +122,7 @@ def test_data_type(orca_session):
     v1 = orca.get_table('tab').get_column('b').values
     np.testing.assert_equal(v1, [0.1, 1.33, 2.4])
     
-    c.data_type = 'int'
+    c.output.data_type = 'int'
     c.run()
 
     v1 = orca.get_table('tab').get_column('b').values
@@ -137,7 +137,7 @@ def test_missing_values(orca_session):
     orca.add_table('tab', pd.DataFrame({'a': [0.1, np.nan, 2.4]}))
     
     c = ColumnFromExpression()
-    c.column_name = 'b'
+    c.output.column_name = 'b'
     c.table = 'tab'
     c.expression = 'a'
     c.run()
@@ -145,7 +145,7 @@ def test_missing_values(orca_session):
     v1 = orca.get_table('tab').get_column('b').values
     np.testing.assert_equal(v1, [0.1, np.nan, 2.4])
     
-    c.missing_values = 5
+    c.output.missing_values = 5
     c.run()
 
     v1 = orca.get_table('tab').get_column('b').values
@@ -158,7 +158,7 @@ def test_modelmanager_registration(orca_session):
     
     """
     c = ColumnFromExpression()
-    c.column_name = 'c'
+    c.output.column_name = 'c'
     c.table = 'obs'
     c.expression = 'a + b'
     
@@ -174,7 +174,7 @@ def test_expression_with_standalone_columns(orca_session):
     
     """
     c = ColumnFromExpression()
-    c.column_name = 'c'
+    c.output.column_name = 'c'
     c.table = 'obs'
     c.expression = 'a + b'
     
@@ -182,7 +182,7 @@ def test_expression_with_standalone_columns(orca_session):
     modelmanager.remove_step(c.meta.name)
 
     d = ColumnFromExpression()
-    d.column_name = 'd'
+    d.output.column_name = 'd'
     d.table = 'obs'
     d.expression = 'a + c'
     

--- a/tests/test_shared_core.py
+++ b/tests/test_shared_core.py
@@ -7,7 +7,7 @@ from urbansim_templates.shared import CoreTemplateSettings
 
 def test_property_persistence():
     """
-    Confirm properties persist through to_dict() and from_dict().
+    Confirm CoreTemplateSettings properties persist through to_dict() and from_dict().
     
     """
     obj = CoreTemplateSettings()

--- a/tests/test_shared_core.py
+++ b/tests/test_shared_core.py
@@ -1,0 +1,26 @@
+from __future__ import print_function
+
+import pytest
+
+from urbansim_templates.shared import CoreTemplateSettings
+
+
+def test_property_persistence():
+    """
+    Confirm properties persist through to_dict() and from_dict().
+    
+    """
+    obj = CoreTemplateSettings()
+    obj.name = 'name'
+    obj.tags = ['tag1', 'tag2']
+    obj.notes = 'notes'
+    obj.autorun = True
+    obj.template = 'CoolNewTemplate'
+    obj.template_version = '0.1.dev0'
+    
+    d = obj.to_dict()
+    print(d)
+    
+    obj2 = CoreTemplateSettings.from_dict(d)
+    assert(obj2.to_dict() == d)
+

--- a/tests/test_shared_output_column.py
+++ b/tests/test_shared_output_column.py
@@ -1,16 +1,20 @@
 from __future__ import print_function
 
+import numpy as np
+import pandas as pd
 import pytest
 
-from urbansim_templates.shared import CoreTemplateSettings
+import orca
+
+from urbansim_templates.shared import OutputColumnSettings, register_column
 
 
 def test_property_persistence():
     """
-    Confirm properties persist through to_dict() and from_dict().
+    Confirm OutputColumnSettings properties persist through to_dict() and from_dict().
     
     """
-    obj = CoreTemplateSettings()
+    obj = OutputColumnSettings()
     obj.column_name = 'column'
     obj.table = 'table'
     obj.data_type = 'int32'
@@ -21,6 +25,71 @@ def test_property_persistence():
     d = obj.to_dict()
     print(d)
     
-    obj2 = CoreTemplateSettings.from_dict(d)
+    obj2 = OutputColumnSettings.from_dict(d)
     assert(obj2.to_dict() == d)
+
+
+# Tests for register_column()..
+
+@pytest.fixture
+def orca_session():
+    """
+    Set up a clean Orca session, with a data table.
+    
+    """
+    orca.clear_all()
+    
+    df = pd.DataFrame({'a': [0.1, 1.33, 2.4]}, index=[1,2,3])
+    orca.add_table('tab', df)
+
+
+def test_column_registration(orca_session):
+    """
+    Confirm column registration works.
+    
+    """
+    series = pd.Series([4,5,6], index=[1,2,3])
+    
+    def build_column():
+        return series
+    
+    settings = OutputColumnSettings(column_name='col', table='tab')
+    register_column(build_column, settings)
+    
+    assert(orca.get_table('tab').get_column('col').equals(series))
+
+
+def test_filling_missing_values(orca_session):
+    """
+    Confirm that filling missing values works.
+    
+    """
+    series1 = pd.Series([4.0, np.nan, 6.0], index=[1,2,3])
+    series2 = pd.Series([4.0, 5.0, 6.0], index=[1,2,3])
+    
+    def build_column():
+        return series1
+    
+    settings = OutputColumnSettings(column_name='col', table='tab', missing_values=5)
+    register_column(build_column, settings)
+    
+    assert(orca.get_table('tab').get_column('col').equals(series2))
+
+
+def test_casting_data_type(orca_session):
+    """
+    Confirm that filling missing values works.
+    
+    """
+    series1 = pd.Series([4.0, 5.0, 6.0], index=[1,2,3])
+    series2 = pd.Series([4, 5, 6], index=[1,2,3])
+    
+    def build_column():
+        return series1
+    
+    settings = OutputColumnSettings(column_name='col', table='tab', data_type='int')
+    register_column(build_column, settings)
+    
+    assert(orca.get_table('tab').get_column('col').equals(series2))
+
 

--- a/tests/test_shared_output_column.py
+++ b/tests/test_shared_output_column.py
@@ -1,0 +1,26 @@
+from __future__ import print_function
+
+import pytest
+
+from urbansim_templates.shared import CoreTemplateSettings
+
+
+def test_property_persistence():
+    """
+    Confirm properties persist through to_dict() and from_dict().
+    
+    """
+    obj = CoreTemplateSettings()
+    obj.column_name = 'column'
+    obj.table = 'table'
+    obj.data_type = 'int32'
+    obj.missing_values = 5
+    obj.cache = True
+    obj.cache_scope = 'iteration'
+    
+    d = obj.to_dict()
+    print(d)
+    
+    obj2 = CoreTemplateSettings.from_dict(d)
+    assert(obj2.to_dict() == d)
+

--- a/urbansim_templates/__init__.py
+++ b/urbansim_templates/__init__.py
@@ -1,1 +1,1 @@
-version = __version__ = '0.2.dev5'
+version = __version__ = '0.2.dev6'

--- a/urbansim_templates/data/__init__.py
+++ b/urbansim_templates/data/__init__.py
@@ -1,3 +1,3 @@
-from .column_from_expression import ColumnFromExpression
+from .column_from_expression import ColumnFromExpression, ExpressionSettings
 from .load_table import LoadTable
 from .save_table import SaveTable

--- a/urbansim_templates/data/column_from_expression.py
+++ b/urbansim_templates/data/column_from_expression.py
@@ -42,12 +42,10 @@ class ExpressionSettings():
 class ColumnFromExpression():
     """
     Template to register a column of derived data with Orca, based on an expression. The 
-    column will be associated with an existing table. Values will be calculated lazily, 
-    only when the column is needed for a specific operation. 
-    
-    The expression will be passed to ``df.eval()`` and can refer to any columns in the 
-    same table. See the Pandas documentation for further details.
-    
+    expression can refer to any columns in the same table, and will be evaluated using
+    ``df.eval()``. Values will be calculated lazily, only when the column is needed for
+    a specific operation.
+        
     Parameters
     ----------
     meta : :mod:`~urbansim_templates.shared.CoreTemplateSettings`, optional
@@ -76,7 +74,7 @@ class ColumnFromExpression():
     def from_dict(cls, d):
         
         if 'meta' not in d:
-            return ColumnFromExpression.from_dict_0_2_dev5(d)
+            return cls.from_dict_0_2_dev5(d)
         
         return cls(
             meta = CoreTemplateSettings.from_dict(d['meta']),
@@ -91,16 +89,19 @@ class ColumnFromExpression():
         
         """
         return cls(
-            column_name = d['column_name'],
-            table = d['table'],
-            expression = d['expression'],
-            data_type = d['data_type'],
-            missing_values = d['missing_values'],
-            cache = d['cache'],
-            cache_scope = d['cache_scope'],
-            name = d['name'],
-            tags = d['tags'],
-            autorun = d['autorun'])
+            meta = CoreTemplateSettings(
+                name = d['name'],
+                tags = d['tags'],
+                autorun = d['autorun']),
+            data = ExpressionSettings(
+                table = d['table'],
+                expression = d['expression']),
+            output = OutputColumnSettings(
+                column_name = d['column_name'],
+                data_type = d['data_type'],
+                missing_values = d['missing_values'],
+                cache = d['cache'],
+                cache_scope = d['cache_scope']))
     
     
     def to_dict(self):

--- a/urbansim_templates/data/column_from_expression.py
+++ b/urbansim_templates/data/column_from_expression.py
@@ -25,7 +25,8 @@ class ColumnFromExpression():
     Parameters
     ----------
     meta : :mod:`~urbansim_templates.shared.CoreTemplateSettings`, optional
-        Stores a name for the configured template and other standard settings.
+        Stores a name for the configured template and other standard settings. For
+        column templates, the default for 'autorun' is True.
     
     column_name : str, optional
         Name of the Orca column to be registered. Required before running.
@@ -64,7 +65,7 @@ class ColumnFromExpression():
             cache_scope = 'forever'):
         
         if meta is None:
-            self.meta = CoreTemplateSettings()
+            self.meta = CoreTemplateSettings(autorun=True)
         
         self.meta.template = self.__class__.__name__
         self.meta.template_version = __version__

--- a/urbansim_templates/data/column_from_expression.py
+++ b/urbansim_templates/data/column_from_expression.py
@@ -7,7 +7,8 @@ from urbansim_templates.shared import CoreTemplateSettings, OutputColumnSettings
 
 class ExpressionSettings():
     """
-    Stores custom parameters used by the ColumnFromExpression template. Parameters can be
+    Stores custom parameters used by the 
+    :mod:`~urbansim_templates.data.ColumnFromExpression` template. Parameters can be
     passed to the constructor or set as attributes.
     
     Parameters
@@ -38,10 +39,11 @@ class ExpressionSettings():
 @modelmanager.template
 class ColumnFromExpression():
     """
-    Template to register a column of derived data with Orca, based on an expression. The 
-    expression can refer to any columns in the same table, and will be evaluated using
-    ``df.eval()``. Values will be calculated lazily, only when the column is needed for
-    a specific operation.
+    Template to register a column of derived data with Orca, based on an expression. 
+    Parameters may be passed to the constructor, but they are easier to set as
+    attributes. The expression can refer to any columns in the same table, and will be
+    evaluated using ``df.eval()``. Values will be calculated lazily, only when the column
+    is needed for a specific operation.
         
     Parameters
     ----------
@@ -69,7 +71,10 @@ class ColumnFromExpression():
 
     @classmethod
     def from_dict(cls, d):
+        """
+        Create a class instance from a saved dictionary.
         
+        """
         if 'meta' not in d:
             return cls.from_dict_0_2_dev5(d)
         
@@ -82,7 +87,8 @@ class ColumnFromExpression():
     @classmethod
     def from_dict_0_2_dev5(cls, d):
         """
-        Converter to read saved data from 0.2.dev5 or earlier.
+        Converter to read saved data from 0.2.dev5 or earlier. Automatically invoked by
+        ``from_dict()`` as needed.
         
         """
         return cls(
@@ -102,6 +108,10 @@ class ColumnFromExpression():
     
     
     def to_dict(self):
+        """
+        Create a dictionary representation of the object.
+        
+        """
         return {
             'meta': self.meta.to_dict(), 
             'data': self.data.to_dict(),
@@ -110,10 +120,8 @@ class ColumnFromExpression():
     
     def run(self):
         """
-        Run the template, registering a column of derived data with Orca.
-        
-        Requires values to be set for ``data.table``, ``data.expression``, and
-        ``output.column_name``.
+        Run the template, registering a column of derived data with Orca. Requires values
+        to be set for ``data.table``, ``data.expression``, and ``output.column_name``.
         
         """
         if self.data.table is None:

--- a/urbansim_templates/data/column_from_expression.py
+++ b/urbansim_templates/data/column_from_expression.py
@@ -116,9 +116,6 @@ class ColumnFromExpression():
         ``output.column_name``.
         
         """
-        
-#         table = self.data.table if self.output.table is None else self.output.table
-        
         if self.data.table is None:
             raise ValueError("Please provide a table")
         
@@ -133,14 +130,6 @@ class ColumnFromExpression():
         if settings.table is None:
             settings.table = self.data.table
 
-        # Some column names in the expression may not be part of the core DataFrame, so 
-        # we'll need to request them from Orca explicitly. This regex pulls out column 
-        # names into a list, by identifying tokens in the expression that begin with a 
-        # letter and contain any number of alphanumerics or underscores, but do not end 
-        # with an opening parenthesis. This will also pick up constants, like "pi", but  
-        # invalid column names will be ignored when we request them from get_df().
-#         cols = re.findall('[a-zA-Z_][a-zA-Z0-9_]*(?!\()', self.data.expression)
-        
         cols = utils.cols_in_expression(self.data.expression)
         
         def build_column():
@@ -149,21 +138,5 @@ class ColumnFromExpression():
             return series
 
         shared.register_column(build_column, settings)
-
-#         @orca.column(table_name = table, 
-#                      column_name = self.output.column_name, 
-#                      cache = self.output.cache, 
-#                      cache_scope = self.output.cache_scope)
-#         def orca_column():
-#             df = get_df(table, columns=cols)
-#             series = df.eval(self.data.expression)
-#             
-#             if self.output.missing_values is not None:
-#                 series = series.fillna(self.output.missing_values)
-#             
-#             if self.output.data_type is not None:
-#                 series = series.astype(self.output.data_type)
-#             
-#             return series
         
     

--- a/urbansim_templates/data/load_table.py
+++ b/urbansim_templates/data/load_table.py
@@ -16,12 +16,11 @@ from urbansim_templates import modelmanager, __version__
 @modelmanager.template
 class LoadTable():
     """
-    Class for registering data tables from local CSV or HDF files.
+    Template for registering data tables from local CSV or HDF files. Parameters can be
+    passed to the constructor or set as attributes.
     
     An instance of this template class stores *instructions for loading a data table*, 
     packaged into an Orca step. Running the instructions registers the table with Orca. 
-    
-    All the parameters can also be set as properties after creating the class instance.
     
     Parameters
     ----------

--- a/urbansim_templates/data/save_table.py
+++ b/urbansim_templates/data/save_table.py
@@ -12,9 +12,8 @@ from urbansim_templates.utils import get_data
 @modelmanager.template
 class SaveTable():
     """
-    Class for saving Orca tables to local CSV or HDF5 files.
-    
-    All the parameters can also be set as properties after creating the class instance.
+    Template for saving Orca tables to local CSV or HDF5 files. Parameters can be passed
+    to the constructor or set as attributes.
     
     Parameters
     ----------

--- a/urbansim_templates/shared/__init__.py
+++ b/urbansim_templates/shared/__init__.py
@@ -1,2 +1,2 @@
 from .core import CoreTemplateSettings
-from .output_column import OutputColumnSettings
+from .output_column import OutputColumnSettings, register_column

--- a/urbansim_templates/shared/__init__.py
+++ b/urbansim_templates/shared/__init__.py
@@ -1,1 +1,2 @@
 from .core import CoreTemplateSettings
+from .output_column import OutputColumnSettings

--- a/urbansim_templates/shared/__init__.py
+++ b/urbansim_templates/shared/__init__.py
@@ -1,0 +1,1 @@
+from .core import CoreTemplateSettings

--- a/urbansim_templates/shared/core.py
+++ b/urbansim_templates/shared/core.py
@@ -64,7 +64,7 @@ class CoreTemplateSettings():
         
         Returns
         -------
-        meta : CoreTemplateSettings
+        obj : CoreTemplateSettings
         
         """
         obj = cls(

--- a/urbansim_templates/shared/core.py
+++ b/urbansim_templates/shared/core.py
@@ -28,11 +28,6 @@ class CoreTemplateSettings():
     template_version : str
         Version of the template class package.
     
-    Attributes
-    ----------
-    modelmanager_version : str
-        Version of the ModelManager package that created the CoreTemplateSettings. 
-    
     """
     def __init__(self,
             name = None,

--- a/urbansim_templates/shared/core.py
+++ b/urbansim_templates/shared/core.py
@@ -1,0 +1,101 @@
+from __future__ import print_function
+
+from urbansim_templates import __version__
+
+
+class CoreTemplateSettings():
+    """
+    Stores standard parameters and logic used by all templates. Parameters can be passed 
+    to the constructor or set as attributes.
+    
+    Parameters
+    ----------
+    name : str, optional
+        Name of the configured template instance.
+    
+    tags : list of str, optional
+        Tags associated with the configured template instance.
+    
+    notes : str, optional
+        Notes associates with the configured template instance.
+    
+    autorun : bool, optional
+        Whether to run the configured template instance automatically when it's 
+        registered or loaded by ModelManager. The overall default is False, but the 
+        default can be overriden at the template level.
+    
+    template : str
+        Name of the template class associated with a configured instance.
+    
+    template_version : str
+        Version of the template class package.
+    
+    Attributes
+    ----------
+    modelmanager_version : str
+        Version of the ModelManager package that created the CoreTemplateSettings. 
+    
+    """
+    def __init__(self,
+            name = None,
+            tags = [],
+            notes = None,
+            autorun = False,
+            template = None,
+            template_version = None):
+        
+        self.name = name
+        self.tags = tags
+        self.notes = notes
+        self.autorun = autorun
+        self.template = template
+        self.template_version = template_version
+        
+        # automatic attributes
+        self.modelmanager_version = __version__
+    
+    
+    @classmethod
+    def from_dict(cls, d):
+        """
+        Create a class instance from a saved dictionary representation.
+        
+        Parameters
+        ----------
+        d : dict
+        
+        Returns
+        -------
+        meta : CoreTemplateSettings
+        
+        """
+        obj = cls(
+            name = d['name'],
+            tags = d['tags'],
+            notes = d['notes'],
+            autorun = d['autorun'],
+            template = d['template'],
+            template_version = d['template_version'],
+        )
+        return d
+    
+    
+    def to_dict(self):
+        """
+        Create a dictionary representation of the object.
+        
+        Returns
+        -------
+        d : dict
+        
+        """
+        d = {
+            'name': self.name,
+            'tags': self.tags,
+            'notes': self.notes,
+            'autorun': self.autorun,
+            'template': self.template,
+            'template_version': self.template_version,
+            'modelmanager_version': self.modelmanager_version,
+        }
+

--- a/urbansim_templates/shared/core.py
+++ b/urbansim_templates/shared/core.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 from urbansim_templates import __version__
 
 
@@ -77,7 +75,7 @@ class CoreTemplateSettings():
             template = d['template'],
             template_version = d['template_version'],
         )
-        return d
+        return obj
     
     
     def to_dict(self):
@@ -98,4 +96,5 @@ class CoreTemplateSettings():
             'template_version': self.template_version,
             'modelmanager_version': self.modelmanager_version,
         }
+        return d
 

--- a/urbansim_templates/shared/output_column.py
+++ b/urbansim_templates/shared/output_column.py
@@ -1,3 +1,5 @@
+import orca
+
 from urbansim_templates import __version__
 
 
@@ -91,3 +93,36 @@ class OutputColumnSettings():
             'cache_scope': self.cache_scope,
             'modelmanager_version': self.modelmanager_version}
 
+
+######################################
+######################################
+
+
+def register_column(build_column, settings):
+    """
+    Register a callable as an Orca column.
+    
+    Parameters
+    ----------
+    build_column : callable
+        Callable should return a ``pd.Series``. 
+    
+    settings : ColumnOutputSettings
+    
+    """
+    @orca.column(table_name = settings.table, 
+                 column_name = settings.column_name, 
+                 cache = settings.cache, 
+                 cache_scope = settings.cache_scope)
+
+    def orca_column():
+        series = build_column()
+        
+        if settings.missing_values is not None:
+            series = series.fillna(settings.missing_values)
+        
+        if settings.data_type is not None:
+            series = series.astype(settings.data_type)
+        
+        return series
+    

--- a/urbansim_templates/shared/output_column.py
+++ b/urbansim_templates/shared/output_column.py
@@ -61,18 +61,16 @@ class OutputColumnSettings():
         
         Returns
         -------
-        meta : OutputColumnSettings
+        obj : OutputColumnSettings
         
         """
-        obj = cls(
+        return cls(
             column_name = d['column_name'],
             table = d['table'],
             data_type = d['data_type'],
             missing_values = d['missing_values'],
             cache = d['cache'],
-            cache_scope = d['cache_scope'],
-        )
-        return obj
+            cache_scope = d['cache_scope'])
     
     
     def to_dict(self):
@@ -84,14 +82,12 @@ class OutputColumnSettings():
         d : dict
         
         """
-        d = {
+        return {
             'column_name': self.column_name,
             'table': self.table,
             'data_type': self.data_type,
             'missing_values': self.missing_values,
             'cache': self.cache,
             'cache_scope': self.cache_scope,
-            'modelmanager_version': self.modelmanager_version,
-        }
-        return d
+            'modelmanager_version': self.modelmanager_version}
 

--- a/urbansim_templates/shared/output_column.py
+++ b/urbansim_templates/shared/output_column.py
@@ -1,0 +1,97 @@
+from urbansim_templates import __version__
+
+
+class OutputColumnSettings():
+    """
+    Stores standard parameters and logic used by templates that generate or modify
+    columns. Parameters can be passed to the constructor or set as attributes.
+    
+    Parameters
+    ----------
+    column_name : str, optional
+        Name of the Orca column to be created or modified. Generally required before
+        running a configured template.
+    
+    table : str, optional
+        Name of Orca table the column will be associated with. Generally required before
+        running the configured template.
+    
+    data_type : str, optional
+        Python type or ``numpy.dtype`` to case the column's values to.
+    
+    missing_values : str or numeric, optional
+        Value to use for rows that would otherwise be missing.
+    
+    cache : bool, default False
+        Whether to cache column values after they are calculated
+    
+    cache_scope : 'step', 'iteration', or 'forever', default 'forever'
+        How long to cache column values for (ignored if ``cache`` is False).
+    
+    """
+    # TO DO: say something about Orca defaults and about core vs. computed columns.
+
+    def __init__(self,
+            column_name = None,
+            table = None,
+            data_type = None,
+            missing_values = None,
+            cache = False,
+            cache_scope = 'forever'):
+        
+        self.column_name = column_name
+        self.table = table
+        self.data_type = data_type
+        self.missing_values = missing_values
+        self.cache = cache
+        self.cache_scope = cache_scope
+        
+        # automatic attributes
+        self.modelmanager_version = __version__
+    
+    
+    @classmethod
+    def from_dict(cls, d):
+        """
+        Create a class instance from a saved dictionary representation.
+        
+        Parameters
+        ----------
+        d : dict
+        
+        Returns
+        -------
+        meta : OutputColumnSettings
+        
+        """
+        obj = cls(
+            column_name = d['column_name'],
+            table = d['table'],
+            data_type = d['data_type'],
+            missing_values = d['missing_values'],
+            cache = d['cache'],
+            cache_scope = d['cache_scope'],
+        )
+        return obj
+    
+    
+    def to_dict(self):
+        """
+        Create a dictionary representation of the object.
+        
+        Returns
+        -------
+        d : dict
+        
+        """
+        d = {
+            'column_name': self.column_name,
+            'table': self.table,
+            'data_type': self.data_type,
+            'missing_values': self.missing_values,
+            'cache': self.cache,
+            'cache_scope': self.cache_scope,
+            'modelmanager_version': self.modelmanager_version,
+        }
+        return d
+

--- a/urbansim_templates/shared/output_column.py
+++ b/urbansim_templates/shared/output_column.py
@@ -5,8 +5,8 @@ from urbansim_templates import __version__
 
 class OutputColumnSettings():
     """
-    Stores standard parameters and logic used by templates that generate or modify
-    columns. Parameters can be passed to the constructor or set as attributes.
+    Stores standard parameters used by templates that generate or modify columns. 
+    Parameters can be passed to the constructor or set as attributes.
     
     Parameters
     ----------

--- a/urbansim_templates/utils.py
+++ b/urbansim_templates/utils.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 
+import re
 from datetime import datetime as dt
 
 import pandas as pd
@@ -345,6 +346,27 @@ def all_cols(table):
     
     return list(table.index.names) + list(table.columns)
     
+
+def cols_in_expression(expression):
+    """
+    Extract all possible column names from a ``df.eval()``-style expression. 
+    
+    This is achieved using regex to identify tokens in the expression that begin with a
+    letter and contain any number of alphanumerics or underscores, but do not end with an
+    opening parenthesis. This excludes function names, but would not exclude constants
+    (e.g. "pi"), which are semantically indistinguishable from column names.
+    
+    Parameters
+    ----------
+    expression : str
+    
+    Returns
+    -------
+    cols : list of str
+    
+    """
+    return re.findall('[a-zA-Z_][a-zA-Z0-9_]*(?!\()', expression)
+
 
 def trim_cols(df, columns=None):
     """


### PR DESCRIPTION
This PR adds the first "settings objects," as proposed in issue #54 and sketched out for the column templates in issue https://github.com/UDST/urbansim_templates/issues/98#issuecomment-478752890. This lets common sets of parameters be defined in a single place, improving consistency and reducing the amount of repeated code.

### New classes

- `shared.CoreTemplateSettings`, with parameters for all templates
- `shared.OutputColumnSettings`, for any template that generates or modifies a column
- `data.ExpressionSettings`, with custom parameters for the `ColumnFromExpression` template

### New shared functions

- `shared.register_column()`, to register a callable as an Orca column
- `utils.col_in_expression()`, to extract column names from a `df.eval()`-style expression

### Update to `ColumnFromExpression`

This allows us to restructure the inputs of the first column template:

```py
meta : CoreTemplateSettings
- name
- tags
- notes
- autorun
data : ExpressionSettings
- table
- expression
output : OutputColumnSettings
- column_name
- table  # set to data.table by default
- data_type
- missing_values
- cache
- cache_scope
```

Old usage:

```py
c = ColumnFromExpression()
c.table = 'zones'
c.expression = 'residential_vacancy_rate * 100'
c.column_name = 'residential_vacancy_pct'
```

New usage:

```py
c = ColumnFromExpression()
c.data.table = 'zones'
c.data.expression = 'residential_vacancy_rate * 100'
c.output.column_name = 'residential_vacancy_pct'
```

### User migration

This breaks the API for `ColumnFromExpression`, but the fixes are easy, as shown above.

For saved YAML files, i've written a converter. When ModelManager opens a saved ColumnFromExpression that uses the older format, it will automatically be loaded correctly: [column_from_expression.py#L73-L104](https://github.com/UDST/urbansim_templates/blob/5d1ed62368db2c8ae83cdb82d37131f3daa67fce/urbansim_templates/data/column_from_expression.py#L73-L104).

(ColumnFromExpression was only added in the prior PR, so i wrote this mostly as a proof of concept for how we can roll out similar updates for other templates.)

### Versioning

0.2.dev6, unless we need to merge something else first

### To do before merging

- [x] CoreTemplateSettings
- [x] OutputColumnSettings
- [x] ExpressionSettings
- [x] factor out shared functions
- [x] test yaml converter
- [x] update documentation
- [x] finalize versioning