### PR TITLE
small bug fix for large mnl simulation re: specification of interaction terms

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pandas >= 0.22
 patsy >= 0.4
 statsmodels >= 0.8
 urbansim >= 3.1
+scipy < 1.3

--- a/urbansim_templates/models/large_multinomial_logit.py
+++ b/urbansim_templates/models/large_multinomial_logit.py
@@ -536,7 +536,11 @@ class LargeMultinomialLogitStep(TemplateStep):
         self.choices = None
         
         if interaction_terms is not None:
-            uniq_intx_idx_names = set([idx for intx in interaction_terms for idx in intx.index.names])
+            if type(interaction_terms) == list:
+                uniq_intx_idx_names = set([
+                    idx for intx in interaction_terms for idx in intx.index.names])
+            else:
+                uniq_intx_idx_names = interaction_terms.index.names
             obs_extra_cols = to_list(self.chooser_size) + list(uniq_intx_idx_names)
             alts_extra_cols = to_list(self.alt_capacity) + list(uniq_intx_idx_names)
 


### PR DESCRIPTION
The original code I wrote to accommodate a list of tables of interaction terms breaks if the interaction terms aren't a list of dataframes but rather a single dataframe, which we don't want. This PR simply fixes the large mnl run() method to account for the latter case.