### PR TITLE
[0.1.3] Patch for "out_transform" in OLS simulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # UrbanSim Templates change log
 
+### 0.1.3 (2019-07-15)
+	
+- fixes a bug with `out_transform` parameter for OLS simulation
+
 ### 0.1.2 (2019-02-28)
 
 - fixes a crash in small MNL simulation

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -10,7 +10,7 @@ UrbanSim Templates provides building blocks for Orca-based simulation models. It
 
 The library contains templates for common types of model steps, plus a tool called ModelManager that runs as an extension to the `Orca <https://udst.github.io/orca>`__ task orchestrator. ModelManager can register template-based model steps with the orchestrator, save them to disk, and automatically reload them for future sessions.
 
-v0.1.2, released February 28, 2019
+v0.1.3, released July 15, 2019
 
 
 Contents

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -10,7 +10,7 @@ UrbanSim Templates provides building blocks for Orca-based simulation models. It
 
 The library contains templates for common types of model steps, plus a tool called ModelManager that runs as an extension to the `Orca <https://udst.github.io/orca>`__ task orchestrator. ModelManager can register template-based model steps with the orchestrator, save them to disk, and automatically reload them for future sessions.
 
-v0.1.3, released July 15, 2019
+v0.1.3, released July 22, 2019
 
 
 Contents

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ requirements = [item.strip() for item in requirements]
 
 setup(
     name='urbansim_templates',
-    version='0.1.2',
+    version='0.1.3',
     description='UrbanSim extension for managing model steps',
     author='UrbanSim Inc.',
     author_email='info@urbansim.com',

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -64,3 +64,23 @@ def test_simulation(orca_session):
     
     assert orca.get_table('obs').to_frame()['a_predicted'].equals(m.predicted_values)
 
+
+def test_out_transform(orca_session):
+    """
+    Test transformation of the predicted values.
+    
+    """
+    modelmanager.initialize()
+
+    m = OLSRegressionStep()
+    m.tables = 'obs'
+    m.model_expression = 'a ~ b'
+    m.fit()
+
+    m.out_column = 'a_predicted'
+    m.out_transform = 'np.exp'
+    m.run()
+
+    predictions = m.predicted_values.apply(np.exp)
+
+    assert orca.get_table('obs').to_frame()['a_predicted'].equals(predictions)

--- a/urbansim_templates/__init__.py
+++ b/urbansim_templates/__init__.py
@@ -1,1 +1,1 @@
-version = __version__ = '0.1.2'
+version = __version__ = '0.1.3'

--- a/urbansim_templates/models/regression.py
+++ b/urbansim_templates/models/regression.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 
+import math
 import numpy as np
 import pandas as pd
 from datetime import datetime as dt
@@ -69,11 +70,13 @@ class OLSRegressionStep(TemplateStep):
         side variable from the model expression will be used. Replaces the `out_fname` 
         argument in UrbanSim.
     
-    out_transform : callable, optional
-        Transformation to apply to the predicted values, for example to reverse a 
-        transformation of the left-hand-side variable in the model expression. Replaces
-        the `ytransform` argument in UrbanSim.
-    
+    out_transform : str, optional
+	    Element-wise transformation to apply to the predicted values, for example to
+	    reverse a transformation of the left-hand-side variable in the model expression.
+	    This should be provided as a string containing a function name. Supports anything
+	    from NumPy or Python's built-in math library, for example 'np.exp' or
+	    'math.floor'. Replaces the `ytransform` argument in UrbanSim.
+	    
     out_filters : str or list of str, optional
         Filters to apply to the data before simulation. If not provided, no filters will
         be applied. Replaces the `predict_filters` argument in UrbanSim.
@@ -168,7 +171,7 @@ class OLSRegressionStep(TemplateStep):
         """
         self.model = RegressionModel(model_expression=self.model_expression,
                 fit_filters=self.filters, predict_filters=self.out_filters,
-                ytransform=self.out_transform, name=self.name)
+                ytransform=None, name=self.name)
 
         results = self.model.fit(self._get_data())
         
@@ -198,7 +201,7 @@ class OLSRegressionStep(TemplateStep):
         self.predicted_values = values
         
         if self.out_transform is not None:
-            values = self.out_transform(values)
+            values = values.apply(eval(self.out_transform))
         
         colname = self._get_out_column()
         tabname = self._get_out_table()


### PR DESCRIPTION
This PR applies the patch from PR #111 (0.2.dev7) to the 0.1.x codebase, so we can release it on pip and conda immediately. The patch fixes the behavior of the `out_transform` parameter in OLS simulation.

### Versioning

0.1.3