### PR TITLE
[0.2.dev9] Binary logit & Regression Add ins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## 0.2 (not yet released)
 
+#### 0.2.dev9 (2020-05-15)
+
+- fixes a bug in `BinaryLogitStep` simulation where the output is not updated correctly
+- adds a `resid` attribute to fitted `OLSRegressionStep` models, for diagnostics
+
+#### 0.2.dev8 (2020-04-17)
+
+- allows segmented large MNL models to be estimated with a `MergedChoiceTable` that's passed in by the user (rather than generated automatically), thus achieving parity with the non-segmented model class
+
 #### 0.2.dev7 (2019-07-15)
 
 - fixes a bug with the `out_transform` parameter for `OLSRegressionStep`

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -10,7 +10,7 @@ UrbanSim Templates provides building blocks for Orca-based simulation models. It
 
 The library contains templates for common types of model steps, plus a tool called ModelManager that runs as an extension to the `Orca <https://udst.github.io/orca>`__ task orchestrator. ModelManager can register template-based model steps with the orchestrator, save them to disk, and automatically reload them for future sessions.
 
-v0.2.dev7, released July 22, 2019
+v0.2.dev9, released July 22, 2019
 
 
 Contents

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='urbansim_templates',
-    version='0.2.dev8', 
+    version='0.2.dev9', 
     description='UrbanSim extension for managing model steps',
     author='UrbanSim Inc.',
     author_email='info@urbansim.com',

--- a/urbansim_templates/__init__.py
+++ b/urbansim_templates/__init__.py
@@ -1,1 +1,1 @@
-version = __version__ = '0.2.dev7'
+version = __version__ = '0.2.dev9'

--- a/urbansim_templates/models/binary_logit.py
+++ b/urbansim_templates/models/binary_logit.py
@@ -227,7 +227,8 @@ class BinaryLogitStep(TemplateStep):
         df = get_data(tables = self.out_tables, 
                       fallback_tables = self.tables,
                       filters = self.out_filters, 
-                      model_expression = self.model_expression)
+                      model_expression = self.model_expression,
+                      extra_columns = self.out_column)
 
         dm = patsy.dmatrices(data=df, formula_like=self.model_expression,
                              return_type='dataframe')[1]  # right-hand-side design matrix

--- a/urbansim_templates/models/regression.py
+++ b/urbansim_templates/models/regression.py
@@ -101,6 +101,7 @@ class OLSRegressionStep(TemplateStep):
         # Placeholders for model fit data, filled in by fit() or from_dict()
         self.summary_table = None 
         self.fitted_parameters = None
+        self.residuals = None
         self.model = None
 
     
@@ -189,7 +190,7 @@ class OLSRegressionStep(TemplateStep):
         # code later on to not rely on RegressionModel any more. 
         
         self.fitted_parameters = results.params.tolist()
-        
+        self.residuals = results.resid
         
     def run(self):
         """


### PR DESCRIPTION
On this PR I'm proposing two small changes:
- In the binary logit `run()` function, the df is built with the `get_data()` function. To the parameters that are passed into this function, I'm adding to the columns to add in the df, the out_columns of the binary model, `extra_columns = self.out_column`, since this column is then used to set the out_true and out_false result values. I have encountered the issue with a household_relocation_model, that the `building_id` which is the out_column, was not appearing in the df, because it was not present in the model_expression nor the out_filters. This caused the update of the column full of null values. 

- In the regression models, I've added the lines to save the residuals when the fitting is done, so the modeler can get the residuals with `model.residuals` for evaluation. The residuals are created using `.resid` which is an element of the `RegressionModel` object.