### PR TITLE
remove filter columns

### DIFF
--- a/urbansim_templates/models/large_multinomial_logit.py
+++ b/urbansim_templates/models/large_multinomial_logit.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 
 import orca
-from urbansim.models.util import columns_in_formula, apply_filter_query
+from urbansim.models.util import columns_in_formula, apply_filter_query, columns_in_filters
 from choicemodels.tools import MergedChoiceTable
 import pandas as pd
 
@@ -603,6 +603,10 @@ class LargeMultinomialLogitStep(TemplateStep):
             alternatives = get_data(tables=self.alternatives,
                                     filters=self.alt_filters,
                                     model_expression=self.model_expression)
+
+            # Remove filter columns before merging, in case column names overlap
+            observations.drop(columns_in_filters(self.chooser_filters), axis = 1, inplace = True)
+            alternatives.drop(columns_in_filters(self.alt_filters), axis = 1, inplace = True)
 
             mct = MergedChoiceTable(observations=observations,
                                     alternatives=alternatives,


### PR DESCRIPTION
When fitting `LargeMultinomialLogitStep` remove variables from filters in case we are using the same filters for observations and alternatives. If that is the case, we will be having the same variable in the observations and alternatives table and we will not be able to calculate the MCT. The idea is similar to what was done for the [run](https://github.com/UDST/urbansim_templates/blob/723b83b4187da53a50ee03fdba4842a464f68240/urbansim_templates/models/large_multinomial_logit.py#L709-L718) method in the same class. 