### PR TITLE
Document project scope and status

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,10 @@ models from declarative settings rather than custom code.
 **Architecture:** UrbanSim Templates is a portable Python layer over Orca,
 UrbanSim, and ChoiceModels. Each template encapsulates the data preparation,
 estimation, and simulation logic for one kind of model step, and persists its
-settings and estimated parameters in portable configuration files. Those files,
-rather than pickled Python objects, are the interface through which model steps
-are reloaded, shared, and executed by other compatible engines.
+settings in portable configuration files. The project's direction is for those
+files, rather than pickled Python objects, to carry all estimated model state,
+so that model steps can be reloaded, shared, and executed by other compatible
+engines.
 
 The project maintains and develops:
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,37 @@ UrbanSim Templates is a Python library that provides building blocks for Orca-ba
 
 The library contains templates for common types of model steps, plus a tool called ModelManager that runs as an extension to the [Orca](https://udst.github.io/orca) task orchestrator. ModelManager can register template-based model steps with the orchestrator, save them to disk, and automatically reload them for future sessions. The package was developed to make it easier to set up new simulation models — model step templates reduce the need for custom code and make settings more portable between models.
 
+## Project scope
+
+**Status:** Active
+
+**Mission:** UrbanSim Templates provides reusable, configurable model-step
+templates and the ModelManager registry for building Orca-based simulation
+models from declarative settings rather than custom code.
+
+**Architecture:** UrbanSim Templates is a portable Python layer over Orca,
+UrbanSim, and ChoiceModels. Each template encapsulates the data preparation,
+estimation, and simulation logic for one kind of model step, and persists its
+settings and estimated parameters in portable configuration files. Those files,
+rather than pickled Python objects, are the interface through which model steps
+are reloaded, shared, and executed by other compatible engines.
+
+The project maintains and develops:
+
+- templates for regression, binary logit, and multinomial logit model steps;
+- templates for loading, saving, and deriving data tables and columns;
+- the ModelManager registry for saving, reloading, and running model steps;
+- shared utilities for data access, filtering, and output handling; and
+- portable configuration formats for estimated model steps.
+
+Development of new templates and configuration-format improvements is welcome
+within this mission and architecture. Material changes to the project's
+mission or execution architecture are considered through UDST's
+organization-level governance process.
+
+See the [UDST Project Directory](https://github.com/UDST/.github/blob/main/PROJECTS.md)
+for organization-wide project status and policy.
+
 ### Installation
 UrbanSim Templates can be installed using the Pip or Conda package managers.
 


### PR DESCRIPTION
## Summary

Adds an explicit mission, architecture, and maintained-scope statement for UrbanSim Templates, and links the repository to the UDST project directory and organization-level scope policy.

This matches the scope documentation added to the other core UDST repositories (UDST/orca#64, UDST/urbansim#237, UDST/choicemodels#80, UDST/pandana#202, UDST/urbanaccess#97). A companion change adds UrbanSim Templates to the organization project directory.

## Scope

This is a documentation-only change aligned with UDST's project governance policy. It makes no functional, dependency, licensing, or repository-setting changes.

Refs #132.
